### PR TITLE
update class selector for JS

### DIFF
--- a/hydra/app/views/bulkrax/importers/_wv_csv_fields.html.erb
+++ b/hydra/app/views/bulkrax/importers/_wv_csv_fields.html.erb
@@ -1,6 +1,4 @@
-<%# OVERRIDE Bulkrax 5.0.0 for debugging %>
-<div class='csv_fields'>
-
+<div class='wv_csv_fields'>
   <%= fi.input :visibility,
     collection: [
       ['Public', 'open'],


### PR DESCRIPTION
ref #10 

On a new import page, the csv parser fields were appearing before the csv parser was selected. Because we are using custom fields for WVU parser, the class selector for removing and appending the fields needed to be adjusted in order for the JS to work properly