### PR TITLE
only load certain items if going through catalog controller

### DIFF
--- a/hydra/app/views/layouts/collection.html.erb
+++ b/hydra/app/views/layouts/collection.html.erb
@@ -34,7 +34,7 @@
     <link href="https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" type="text/css" rel="stylesheet">
 
     <!-- Hydra Code -->
-    <%#= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>
+    <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') if controller.class == CatalogController %>
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= csrf_meta_tags %>
     <%= yield :head %>

--- a/hydra/app/views/layouts/collection_no_header.html.erb
+++ b/hydra/app/views/layouts/collection_no_header.html.erb
@@ -33,7 +33,7 @@
     <link href="https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" type="text/css" rel="stylesheet">
 
     <!-- Hydra Code -->
-    <%#= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>
+    <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') if controller.class == CatalogController %>
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= csrf_meta_tags %>
 

--- a/hydra/app/views/shared/_navigation.html.erb
+++ b/hydra/app/views/shared/_navigation.html.erb
@@ -1,5 +1,3 @@
-<%# OVERRIDE Bulkrax 5.0.0 for debugging had to comment out some things that were erroring when viewing importers index %>
-
 <!-- Website Tab Bar -->
 <div class="sticky-header">
   <div class="tbwrap">
@@ -9,8 +7,7 @@
               <%= image_tag("x.svg", alt: "Search Close", id:
               "search-toggle2") %>
           </a>
-
-          <%#= render_search_bar  %>
+          <%= render_search_bar if controller.class == CatalogController  %>
       </div>
       <div class="sticky-header-nav tabBar">
           <a id="menu-toggle">

--- a/hydra/app/views/shared/_user_util_links.html.erb
+++ b/hydra/app/views/shared/_user_util_links.html.erb
@@ -1,9 +1,9 @@
-<%# OVERRIDE Bulkrax 5.0.0 for debugging had to comment out some things that were erroring when viewing importers index %>
-
 <div class="navbar-right">
   <ul class="nav navbar-nav">
-    <%#= render_nav_actions do |config, action|%>
-      <li class="nav-item"><%#= action %></li>
-    <%# end %>
+  <% if controller.class == CatalogController %>
+    <%= render_nav_actions do |config, action|%>
+      <li class="nav-item"><%= action %></li>
+    <% end %>
+  <% end %>
   </ul>
 </div>


### PR DESCRIPTION
ref #16 #17 #18 

Only load these items if we are going through the catalog controller and not bulkrax controllers.

Reasoning - if you are running importers or exporters, you are not going to be utilizing the blacklight search or bookmark functions, so this prevents the search bar and bookmarks from loading on the Bulkrax views