### PR TITLE
add commented configs for local Bulkrax dev work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+hydra/vendor/engines

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get -y install cron postgresql-client
 RUN apt-get install -y libjemalloc2 libjemalloc-dev
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
 
+# Uncomment if developing Bulkrax within this application
+# COPY ./hydra/vendor/engines/bulkrax /home/hydra/vendor/engines/bulkrax
+
 RUN \
   gem update --system --quiet && \
   gem install bundler -v ${BUNDLER_VERSION} && \

--- a/hydra/Gemfile
+++ b/hydra/Gemfile
@@ -33,7 +33,9 @@ gem 'whenever', require: false
 
 # Bulkrax Import
 # =====================================================
+# Switch the comments on these two lines to work on Bulkrax locally
 gem 'bulkrax'
+# gem 'bulkrax', path: 'vendor/engines/bulkrax'
 gem 'simple_form'
 
 # background jobs


### PR DESCRIPTION
Requires cloning Bulkrax into `hydra/vendor/engines` 