### PR TITLE
i14 Bundle simple_form through Bulkrax

### DIFF
--- a/hydra/Gemfile
+++ b/hydra/Gemfile
@@ -34,7 +34,6 @@ gem 'whenever', require: false
 # Bulkrax Import
 # =====================================================
 gem 'bulkrax'
-gem 'simple_form'
 
 # background jobs
 # =====================================================

--- a/hydra/Gemfile.lock
+++ b/hydra/Gemfile.lock
@@ -443,7 +443,6 @@ DEPENDENCIES
   sidekiq (< 7)
   sidekiq-cron
   sidekiq-failures
-  simple_form
   solr_wrapper (~> 2.0)
   solrizer
   spring

--- a/hydra/config/initializers/simple_form.rb
+++ b/hydra/config/initializers/simple_form.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-#
+
+require 'simple_form'
 # Uncomment this and change the path if necessary to include your own
 # components.
 # See https://github.com/heartcombo/simple_form#custom-components to know


### PR DESCRIPTION
Ref #14 

# Story

Resolves this error when spinning up the web process locally without needing to specify the simple_form gem in the local Gemfile:

```
uninitialized constant SimpleForm in hydra/config/initializers/simple_form.rb
```

# Expected Behavior Before Changes

The web (`acda_portal`) container crashes when spinning it up locally (using the `docker-compose.dev.local.yml` file) 

# Expected Behavior After Changes

The web (`acda_portal`) container successfully spins up locally (using the `docker-compose.dev.local.yml` file) 