### PR TITLE
disable devise auth

### DIFF
--- a/hydra/app/controllers/application_controller.rb
+++ b/hydra/app/controllers/application_controller.rb
@@ -18,4 +18,9 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+  # redefines authenticate_user! to do nothing, which disables devise authentication for all controller actions throughout the app
+  # removing the following 2 lines will re-enable devise auth
+  def authenticate_user!
+  end
 end


### PR DESCRIPTION
# Summary
wvu is currently not using devise authentication for their app, but the bulkrax routes hit the devise login pages.
this PR prevents logging into devise auth from being necessary throughout the app.

# Related
#48 

# Video
https://share.getcloudapp.com/kpuA4A1y

# Acceptance Criteria
- as a user, i do not hit login pages after logging in to basic auth for the `importers` and `exporters` routes