### PR TITLE
Specify which properties should split in parser

### DIFF
--- a/hydra/config/initializers/bulkrax.rb
+++ b/hydra/config/initializers/bulkrax.rb
@@ -49,7 +49,7 @@ Bulkrax.setup do |config|
       'edtf' => { from: ['dcterms:created'] },
       'creator' => { from: ['dcterms:creator'] },
       'rights' => { from: ['dcterms:rights'] },
-      'language' => { from: ['dcterms:language'] },
+      'language' => { from: ['dcterms:language'], split: true },
       'congress' => { from: ['dcterms:temporal'] },
       'collection_title' => { from: ['dcterms:relation'] },
       'physical_location' => { from: ['dcterms:isPartOf'] },
@@ -64,7 +64,7 @@ Bulkrax.setup do |config|
       'dc_type' => { from: ['dcterms:type'] },
       'record_type' => { from: ['dcterms:http://purl.org/dc/terms/type'], split: true },
       'format' => { from: ['dcterms:format'] },
-      'publisher' => { from: ['dcterms:publisher'] }
+      'publisher' => { from: ['dcterms:publisher'], split: true }
     }
   }
 

--- a/hydra/config/initializers/bulkrax.rb
+++ b/hydra/config/initializers/bulkrax.rb
@@ -56,13 +56,13 @@ Bulkrax.setup do |config|
       'collection_finding_aid' => { from: ['dcterms:source'] },
       'bulkrax_identifier' => { from: ['bulkrax_identifier'], source_identifier: true },
       'identifier' => { from: ['dcterms:identifier'] },
-      'topic' => { from: ['dcterms:subject'] },
+      'topic' => { from: ['dcterms:subject'], split: true },
       'preview' => { from: ['edm:preview'] },
       'available_at' => { from: ['edm:isShownAt'] },
       'description' => { from: ['dcterms:description'] },
-      'names' => { from: ['dcterms:contributor'] },
+      'names' => { from: ['dcterms:contributor'], split: true },
       'dc_type' => { from: ['dcterms:type'] },
-      'record_type' => { from: ['dcterms:http://purl.org/dc/terms/type'] },
+      'record_type' => { from: ['dcterms:http://purl.org/dc/terms/type'], split: true },
       'format' => { from: ['dcterms:format'] },
       'publisher' => { from: ['dcterms:publisher'] }
     }
@@ -103,7 +103,7 @@ Bulkrax.setup do |config|
   # config.qa_controlled_properties += ['my_field']
 
   # Specify the delimiter regular expression for splitting an attribute's values into a multi-value array.
-  # config.multi_value_element_split_on = //\s*[:;|]\s*/.freeze
+  # config.multi_value_element_split_on = /\s*[:;|]\s*/.freeze
 
   # Specify the delimiter for joining an attribute's multi-value array into a string.  Note: the
   # specific delimeter should likely be present in the multi_value_element_split_on expression.


### PR DESCRIPTION
# Story
- client requested that the following 4 properties would split on a semi colon
- [ ]  Names
- [ ]  Policy Area
- [ ]  Record Type
- [ ]  Topic

- Bulkrax has this functionality by default, its just that they needed to be specified. Note that both Policy Area and Topic pull from Topic. 

# Related
#73 

# Expected Behavior Before Changes
Properties imported as a single string

# Expected Behavior After Changes
- [ ]  Names
- [ ]  Policy Area
- [ ]  Record Type
- [ ]  Topic
Properties split into  multi-value arrays, split by a semi colon in the csv cells

# Screenshots / Video

<details>
<summary>Properties splitting correctly after changes</summary>

<img width="667" alt="Screen Shot 2023-07-13 at 15 14 48" src="https://github.com/scientist-softserv/west-virginia-university/assets/73361970/289bfc40-eb2e-458b-b5cc-ac1c1ddb4b44">

<img width="726" alt="Screen Shot 2023-07-13 at 15 16 39" src="https://github.com/scientist-softserv/west-virginia-university/assets/73361970/a9515b56-4123-4097-861e-1e426e178f38">


</details>
