### PR TITLE
64- Fix round tripping

### DIFF
--- a/hydra/app/factories/bulkrax/acda_factory.rb
+++ b/hydra/app/factories/bulkrax/acda_factory.rb
@@ -89,12 +89,14 @@ module Bulkrax
       # TODO: implement with files or remove
       # @transform_attributes.merge!(file_attributes(update_files)) if with_files
       @transform_attributes = remove_blank_hash_values(@transform_attributes) if transformation_removes_blank_hash_values?
-      # TODO: Should we filter these out earlier in the process? I.e. before they get into :attributes or when we're
-      #       parsing the metadata? I don't think we currently know enough about what :attributes will look like
-      #       at this point to say for sure yet.
+      # if we are updating an item, remove ID from the list of attributes.
+      # ID should be ignored for existing works.
+      # for all works, file path fields should be ignored.
       exceptions = update ? [:id] + file_path_field_names : file_path_field_names
-
-      @transform_attributes.except(exceptions)
+      exceptions.each do |exception|
+        transformed = @transform_attributes.except!(exception)
+      end
+      @transform_attributes
     end
 
     # Regardless of what the Parser gives us, these are the properties we are prepared to accept.


### PR DESCRIPTION
# Story
Fixes roundtripping for wvu hydra bulkrax. 

# Related
- #64 

# Expected Behavior Before Changes
- an error was thrown when trying to reimport/update existing works. ID should not be updated for existing works. 
<img width="700" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/73361970/e04f9dd1-c1b6-4f21-af7c-8d42971667e7">

# Expected Behavior After Changes
- users should be able to reimport existing works without creating duplicates
- users should be able to update existing works without creating duplicates

# Screenshots / Video

Video: https://github.com/scientist-softserv/west-virginia-university/pull/new/64-fix-round-tripping
