### PR TITLE
put bootstrap's JS in hydra instead of in bulkrax to be similar to hy…

### DIFF
--- a/hydra/app/assets/javascripts/application.js
+++ b/hydra/app/assets/javascripts/application.js
@@ -11,10 +11,11 @@
 // about supported directives.
 //
 
-// Rails or Hydra Requirements 
+// Rails or Hydra Requirements
 // -----------------------------------------------------
 //= require jquery
 //= require jquery_ujs
+//= require bootstrap
 
 // Required by Blacklight
 // -----------------------------------------------------
@@ -24,7 +25,7 @@
 // -----------------------------------------------------
 //= require bulkrax/application
 
-// CUSTOM COLLECTION JS 
+// CUSTOM COLLECTION JS
 // -----------------------------------------------------
 //= require partials/equal_heights
 //= require partials/facets


### PR DESCRIPTION
# Summary
- Bulkrax relies on bootstrap's JS
- put bootstrap's JS in hydra's JS file instead of in bulkrax to be similar to hyrax & hyku
