### PR TITLE
🎁 Add Advanced Search

### DIFF
--- a/hydra/Gemfile
+++ b/hydra/Gemfile
@@ -53,6 +53,7 @@ gem 'sidekiq-failures'
 gem 'active-fedora'
 gem 'active-triples'
 gem 'blacklight'
+gem 'blacklight_advanced_search'
 
 gem 'hydra-head'
 gem 'ldp'

--- a/hydra/Gemfile.lock
+++ b/hydra/Gemfile.lock
@@ -101,6 +101,9 @@ GEM
       blacklight (> 6.0, < 8)
       cancancan (>= 1.8)
       deprecation (~> 1.0)
+    blacklight_advanced_search (6.4.1)
+      blacklight (~> 6.0, >= 6.0.1)
+      parslet
     blacklight_oai_provider (6.1.1)
       blacklight (~> 6.0)
       oai (~> 1.0)
@@ -270,6 +273,7 @@ GEM
       time
       uri
     orm_adapter (0.5.0)
+    parslet (2.0.0)
     pg (1.4.5)
     puma (4.3.12)
       nio4r (~> 2.0)
@@ -435,6 +439,7 @@ DEPENDENCIES
   active-fedora
   active-triples
   blacklight
+  blacklight_advanced_search
   blacklight_oai_provider
   bootsnap (>= 1.1.0)
   bulkrax!

--- a/hydra/app/assets/javascripts/application.js
+++ b/hydra/app/assets/javascripts/application.js
@@ -14,6 +14,9 @@
 // Rails or Hydra Requirements
 // -----------------------------------------------------
 //= require jquery
+//= require 'blacklight_advanced_search'
+
+
 //= require jquery_ujs
 //= require bootstrap
 

--- a/hydra/app/assets/stylesheets/application.scss
+++ b/hydra/app/assets/stylesheets/application.scss
@@ -11,7 +11,10 @@
  * It is generally better to create a new file per style scope.
  *
  *= require_self
- */
+ 
+ *= require 'blacklight_advanced_search'
+
+*/
  
 
 // import custom scss 

--- a/hydra/app/blacklight/access_controls/search_builder_decorator.rb
+++ b/hydra/app/blacklight/access_controls/search_builder_decorator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+##
+# OVERRIDE blacklight-access_controls v6.0.1
+module Blacklight
+  module AccessControls
+    ##
+    # Override Blacklight::AccessControls::SearchBuilder to smooth over conflicting parameter
+    # signature for the {#initialize} method.
+    module SearchBuilderDecorator
+      ##
+      # @note When requesting GET `/advanced`, we initialize a
+      #       Blacklight::AccessControls::SearchBuilder twice.  One of those times the
+      #       initialization comes from Blacklight::AccessControls the other comes from Blacklight.
+      #       And each attempts to initialize with a different method signature.  I have provided
+      #       links to those different initialization end-points.
+      #
+      # @see https://github.com/projectblacklight/blacklight-access_controls/blob/bfa3c9cd5a32648cb9739f503afec3b690b15750/lib/blacklight/access_controls/catalog.rb#L20-L22
+      # @see https://github.com/projectblacklight/blacklight-access_controls/blob/bfa3c9cd5a32648cb9739f503afec3b690b15750/lib/blacklight/access_controls/search_builder.rb#L23-L31
+      # @see https://github.com/projectblacklight/blacklight/blob/f07cc24d64702f9f2700df2d258d5ba797747210/lib/blacklight/search_builder.rb#L20-L39
+      def initialize(*args)
+        case args.first
+        when ActionController::Base
+          Rails.logger.debug("#{self.class}##{__method__} with controller as first parameter; caller: #{caller[0]}")
+          super
+        when Array
+          if args.first.all? { |elements| elements.is_a?(Symbol) }
+            Rails.logger.debug("#{self.class}##{__method__} with processor_chain as first parameter; caller: #{caller[0]}")
+            self.default_processor_chain = args.first
+            super(args[1], ability: args[1].current_ability)
+          else
+            Rails.logger.debug("#{self.class}##{__method__} with an attempt at a processor_chain as first parameter; caller: #{caller[0]}.  Best wishes on debugging.")
+            raise RuntimeError, "Expected #{args.first.inspect} to be an array of symbols, which would likely be a default_processor_chain"
+          end
+        else
+          Rails.logger.debug("#{self.class}##{__method__} received with an unknown initial parameter; caller: #{caller[0]}.  Best wishes on debugging.")
+          raise RuntimeError, "Expected #{args.first.inspect} to be an Array of symbols or an ActionController::Base, got #{args.first.class}"
+        end
+      end
+    end
+  end
+end
+
+Blacklight::AccessControls::SearchBuilder.prepend(Blacklight::AccessControls::SearchBuilderDecorator)

--- a/hydra/app/controllers/catalog_controller.rb
+++ b/hydra/app/controllers/catalog_controller.rb
@@ -2,6 +2,7 @@
 require 'blacklight/catalog'
 
 class CatalogController < ApplicationController
+  include BlacklightAdvancedSearch::Controller
 
   include Hydra::Catalog
   include BlacklightOaiProvider::Controller
@@ -9,6 +10,13 @@ class CatalogController < ApplicationController
   # before_action :enforce_show_permissions, only: :show
 
   configure_blacklight do |config|
+    # default advanced config values
+    config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
+    # config.advanced_search[:qt] ||= 'advanced'
+    config.advanced_search[:url_key] ||= 'advanced'
+    config.advanced_search[:query_parser] ||= 'dismax'
+    config.advanced_search[:form_solr_parameters] ||= {}
+
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
 

--- a/hydra/app/controllers/saved_searches_controller.rb
+++ b/hydra/app/controllers/saved_searches_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SavedSearchesController < ApplicationController
+  include Blacklight::SavedSearches
+
+  helper BlacklightAdvancedSearch::RenderConstraintsOverride
+end

--- a/hydra/app/controllers/search_history_controller.rb
+++ b/hydra/app/controllers/search_history_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SearchHistoryController < ApplicationController
+  include Blacklight::SearchHistory
+
+  helper BlacklightAdvancedSearch::RenderConstraintsOverride
+end

--- a/hydra/app/models/search_builder.rb
+++ b/hydra/app/models/search_builder.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightAdvancedSearch::AdvancedSearchBuilder
+  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
 
   # Custom Processing of Holt only Records 
   # self.default_processor_chain += [:show_only_acda_records]

--- a/hydra/app/views/catalog/_search_form.html.erb
+++ b/hydra/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_tag search_action_url, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <div class="input-group">
+    <% if search_fields.length > 1 %>
+      <span class="input-group-addon for-search-field">
+        <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+        <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), title: t('blacklight.search.form.search_field.title'), id: "search_field", class: "search_field") %>
+      </span>
+    <% elsif search_fields.length == 1 %>
+      <%= hidden_field_tag :search_field, search_fields.first.last %>
+    <% end %>
+
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
+
+    <span class="input-group-btn">
+      <button type="submit" class="btn btn-primary search-btn" id="search">
+        <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
+        <span class="glyphicon glyphicon-search"></span>
+      </button>
+    </span>
+  </div>
+<% end %>
+
+
+
+<div class="navbar-form">
+  <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-default'%>
+</div>

--- a/hydra/app/views/catalog/_search_form.html.erb
+++ b/hydra/app/views/catalog/_search_form.html.erb
@@ -18,12 +18,7 @@
         <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
         <span class="glyphicon glyphicon-search"></span>
       </button>
+      <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-default'%>
     </span>
   </div>
 <% end %>
-
-
-
-<div class="navbar-form">
-  <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-default'%>
-</div>

--- a/hydra/config/routes.rb
+++ b/hydra/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
   get '/featured' => 'featured#index'
   
   mount Blacklight::Engine => '/'
+  mount BlacklightAdvancedSearch::Engine => '/'
+
   root to: 'catalog#index'
     concern :searchable, Blacklight::Routes::Searchable.new
 


### PR DESCRIPTION
## ⚙️ Add blacklight_advanced_search gem

b4bf572d9ece40ba7aeb9cbd61132456458ef6f1

Once I added the `blacklight_advanced_search` gem, I ran the following:
    
```
docker compose exec web bundle
```
    
This added `blacklight_advanced_search` to the gem dependency graph by
updating the `Gemfile.lock`
    
Related to:
    
- https://github.com/scientist-softserv/west-virginia-university/issues/98

## 🎁 Install blacklight_advanced_search

749ab835c54f8f91437e9410e2b85f0033e0bb9e
    
These files were generated via:
    
```
docker compose exec web rails generate blacklight_advanced_search:install
```
    
*Note:* The documentation said to run `rails generate
blacklight_advanced_search`, however during the installation it
mentioned that was deprecated in favor of the above.  So I reset and ran
the command based on the guidance of the generator (figuring that
guidance was likely more correct).
    
During the installation, the generator asked:
    
> Install local search form with advanced link? (y/N)
    
I answered `y`.
    
Related to:
    
- https://github.com/scientist-softserv/west-virginia-university/issues/98

##    💄 Move "More options" button beside Search

17c776a7d1bd0fdd0a65130216a80e1f2dab4cd1

Prior to this commit, the "More Options" floated beneath the form;
looking very much out of place.
    
With this change, it's inline and appropriate.

<details><summary>Before</summary>
<img width="476" alt="Screenshot 2023-10-19 at 11 33 21 AM" src="https://github.com/scientist-softserv/west-virginia-university/assets/2130/263608a7-294b-4d09-a435-b80083563b29">

</details>

<details><summary>After</summary>
<img width="552" alt="Screenshot 2023-10-19 at 10 14 15 AM" src="https://github.com/scientist-softserv/west-virginia-university/assets/2130/47b1b13e-d9ea-4a4f-8dbf-a4ad1ed329d2">
</details>

##    ♻️ Add SearchBuilder#initialize parameter handler

97c6980dd35732f901f91087749bed3fc97c1e88

Prior to this commit I was getting the following exception:
    
```
ArgumentError in AdvancedController#index
wrong number of arguments (given 2, expected 1; required keyword:
ability)
```
    
It turns out that during the AdvancedController#index request cycle we
instantiate `Blacklight::AccessControls::SearchBuilder` multiple times;
and with different parameter signatures.
    
Below are the logged calls of
`Blacklight::AccessControls::SearchBuilder`; note we have only minimal
application changes so this appears to be a conflict between versions.
    
```
Blacklight::AccessControls::SearchBuilder#initialize with controller as first parameter; caller: /usr/local/bundle/gems/blacklight-access_controls-6.0.1/lib/blacklight/access_controls/catalog.rb:21:in `new'
Blacklight::AccessControls::SearchBuilder#initialize with processor_chain as first parameter; caller: /usr/local/bundle/gems/blacklight-6.25.0/lib/blacklight/search_builder.rb:81:in `new'
Blacklight::AccessControls::SearchBuilder#initialize with processor_chain as first parameter; caller: /usr/local/bundle/gems/blacklight-6.25.0/lib/blacklight/search_builder.rb:61:in `new'
```
    
With this commit, I'm introducing a crease in the code to re-arrange the
method signature.  In doing so the exception mentioned above goes away,
and I see the advanced search page.
    
<details><summary>Before</summary>
<img width="1015" alt="Screenshot 2023-10-19 at 10 16 11 AM" src="https://github.com/scientist-softserv/west-virginia-university/assets/2130/564cb4c8-35a6-44e3-82c5-2e63be7975bc">
</details>

<details><summary>After</summary>
<img width="1216" alt="Screenshot 2023-10-19 at 11 34 43 AM" src="https://github.com/scientist-softserv/west-virginia-university/assets/2130/dc2e7ac5-cc2c-492f-a846-075d083af9d2">
</details>

Related to:
    
- https://github.com/scientist-softserv/west-virginia-university/issues/98