### PR TITLE
Softserv dev (#10)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 # Story
 
-Refs #issuenumber
+Refs:
+
+- #issuenumber
 
 # Expected Behavior Before Changes
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,74 @@
+# Getting Started
+
+For SoftServ development there are two repositories:
+
+- SoftServ's :: https://github.com/scientist-softserv/west-virginia-university
+- WVU's :: https://github.com/wvulibraries/hydra_acda_portal_public
+
+SoftServ's is a fork of WVU.
+
+In SoftServ there are two important branches: `main` and `softserv-dev`.  The `main` branch tracks to WVU's `main` branch; and likewise for `softserv-dev`.
+
+The SoftServ `main` has changes necessary for building your local docker instance.  Those changes should not be merged into `softserv-dev` nor into any of WVU's branches.
+
+## Procedure: Workflow
+
+- Clone SoftServ's repository
+- Checkout the SoftServ's `main` branch
+- Run `docker compose -f docker-compose.dev.yml build` to build the instance.
+- Once build, checkout `softserv-dev`.
+- Run `docker compose -f docker-compose.dev.yml up` to spin up the built instance.
+
+You need to start branches from `softserv-dev` and submit PRs to SoftServ's Github repository; the SoftServ team will review the changes and we then merge those changes into SoftServ's `softserv-dev` branch.
+
+ **_Note_**: There is no automated deploy for SoftServ; nor do we have a staging environment.  SoftServ QA is handled on a local instance; and WVU QA is handled by them spinning up a staging environment.
+
+At this point, we do local QA against SoftServ's `softserv-dev` branch.  When it passes internal QA, we can move the ticket. 
+
+We then need to send that code to WVU for review.  We also will submit PRs from SoftServ's `softserv-dev` branch to WVU's `softserv-dev` branch.  When we submit those PRs:
+
+- Check the commits to review what will be sent to WVU
+- Ping the developers at WVU to have them review and ultimately spin up a staging environment. 
+
+I suspect that the flow of changes will be uni-directional; code will likely only be going into WVU `softserv-dev`.  If that suspicion is not the case, we'll determine the best approach to bring changes for WVU's `softserv-dev` branch into SoftServ's branch.  Likewise for changes added to `main`; though I suspect those are unlikely.
+
+## Procedure: Adding Changes to SoftServ's main and softserv-dev branches
+
+When you need to add changes to both `main` and `softserv-dev`, follow the above process to get code into `softserv-dev`. 
+
+Then:
+
+- Checkout SoftServ's `main` branch.
+- Create a new branch from SoftServ's `main` branch.
+- Cherry pick the commits you want from SoftServ's `softserv-dev` branch.
+- Submit a PR from this new branch to SoftServ's `main` branch.
+
+The goal of the above is three-fold:
+
+- to keep SoftServ's `main` aligned with WVU's `main`
+- to keep SoftServ's `softserv-dev` aligned with WVU's `softserv-dev`
+- to propagate SoftServ documentation to `main` and `softserv-dev` to help developers in their wayfinding.
+
+Note, there are cases where we will first add documentation to `main` and then propogage that to `softserv-dev`.
+
+## Local Development
+
+The `up.sh` command uses the `docker-compose.dev.yml` file for it’s build process.  This will both build and bring up the containers.  You can access the application at http://localhost:3000.  When I first accessed the application, I had to shell into the `web` container and run `bundle exec rake db:create db:migrate`.  To shell into the `web` container use the following: `docker compose -f docker-compose.dev.yml exec web bash`.
+
+If you prefer to start the `web` and `workers` services individually, you can use `docker-compose.dev.debug.yml` as part of the composition.
+
+```
+docker compose -f docker-compose.dev.yml -f docker-compose.dev.debug.yml up
+```
+
+You'll then need to shell into the containers to start the services.
+
+### Adding Content
+
+To get data into the app:
+
+- Navigate to http://localhost:3000/importers?locale-en to import via bulkrax csv
+- Sample csv files are on the roundtripping ticket:
+  - https://github.com/scientist-softserv/west-virginia-university/issues/104
+- You will have to log into the popup.  The username is in `ENV['BULKRAX_USERNAME']` and the password is in `ENV['BULKRAX_PW']`.  For local development, see [./env/env.dev.hydra](./env/env.dev.hydra).    
+  - Barring that, shell into the web container (e.g. `docker compose -f docker-compose.dev.yml exec web bash`) and run `echo "$BULKRAX_USERNAME:$BULKRAX_PW"`.

--- a/docker-compose.dev.debug.yml
+++ b/docker-compose.dev.debug.yml
@@ -1,0 +1,14 @@
+##
+# The purpose of this override is to allow for you bring up all but the workers
+# and web container.  You can then shell into those containers to start the
+# underlying services (as defined in the other docker-compose files).
+#
+# Example:
+#
+# $ docker compose -f docker-compose.dev.yml -f docker-compose.dev.debug.yml up
+version: '3.4'
+services:
+  web:
+    command: tail -f /dev/null
+  workers:
+    command: tail -f /dev/null

--- a/hydra/Gemfile
+++ b/hydra/Gemfile
@@ -53,6 +53,7 @@ gem 'sidekiq-failures'
 gem 'active-fedora'
 gem 'active-triples'
 gem 'blacklight'
+gem 'blacklight_advanced_search'
 
 gem 'hydra-head'
 gem 'ldp'

--- a/hydra/Gemfile.lock
+++ b/hydra/Gemfile.lock
@@ -101,6 +101,9 @@ GEM
       blacklight (> 6.0, < 8)
       cancancan (>= 1.8)
       deprecation (~> 1.0)
+    blacklight_advanced_search (6.4.1)
+      blacklight (~> 6.0, >= 6.0.1)
+      parslet
     blacklight_oai_provider (6.1.1)
       blacklight (~> 6.0)
       oai (~> 1.0)
@@ -270,6 +273,7 @@ GEM
       time
       uri
     orm_adapter (0.5.0)
+    parslet (2.0.0)
     pg (1.4.5)
     puma (4.3.12)
       nio4r (~> 2.0)
@@ -435,6 +439,7 @@ DEPENDENCIES
   active-fedora
   active-triples
   blacklight
+  blacklight_advanced_search
   blacklight_oai_provider
   bootsnap (>= 1.1.0)
   bulkrax!

--- a/hydra/app/assets/javascripts/application.js
+++ b/hydra/app/assets/javascripts/application.js
@@ -14,6 +14,9 @@
 // Rails or Hydra Requirements
 // -----------------------------------------------------
 //= require jquery
+//= require 'blacklight_advanced_search'
+
+
 //= require jquery_ujs
 //= require bootstrap
 

--- a/hydra/app/assets/stylesheets/application.scss
+++ b/hydra/app/assets/stylesheets/application.scss
@@ -11,7 +11,10 @@
  * It is generally better to create a new file per style scope.
  *
  *= require_self
- */
+ 
+ *= require 'blacklight_advanced_search'
+
+*/
  
 
 // import custom scss 

--- a/hydra/app/blacklight/access_controls/search_builder_decorator.rb
+++ b/hydra/app/blacklight/access_controls/search_builder_decorator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+##
+# OVERRIDE blacklight-access_controls v6.0.1
+module Blacklight
+  module AccessControls
+    ##
+    # Override Blacklight::AccessControls::SearchBuilder to smooth over conflicting parameter
+    # signature for the {#initialize} method.
+    module SearchBuilderDecorator
+      ##
+      # @note When requesting GET `/advanced`, we initialize a
+      #       Blacklight::AccessControls::SearchBuilder twice.  One of those times the
+      #       initialization comes from Blacklight::AccessControls the other comes from Blacklight.
+      #       And each attempts to initialize with a different method signature.  I have provided
+      #       links to those different initialization end-points.
+      #
+      # @see https://github.com/projectblacklight/blacklight-access_controls/blob/bfa3c9cd5a32648cb9739f503afec3b690b15750/lib/blacklight/access_controls/catalog.rb#L20-L22
+      # @see https://github.com/projectblacklight/blacklight-access_controls/blob/bfa3c9cd5a32648cb9739f503afec3b690b15750/lib/blacklight/access_controls/search_builder.rb#L23-L31
+      # @see https://github.com/projectblacklight/blacklight/blob/f07cc24d64702f9f2700df2d258d5ba797747210/lib/blacklight/search_builder.rb#L20-L39
+      def initialize(*args)
+        case args.first
+        when ActionController::Base
+          Rails.logger.debug("#{self.class}##{__method__} with controller as first parameter; caller: #{caller[0]}")
+          super
+        when Array
+          if args.first.all? { |elements| elements.is_a?(Symbol) }
+            Rails.logger.debug("#{self.class}##{__method__} with processor_chain as first parameter; caller: #{caller[0]}")
+            self.default_processor_chain = args.first
+            super(args[1], ability: args[1].current_ability)
+          else
+            Rails.logger.debug("#{self.class}##{__method__} with an attempt at a processor_chain as first parameter; caller: #{caller[0]}.  Best wishes on debugging.")
+            raise RuntimeError, "Expected #{args.first.inspect} to be an array of symbols, which would likely be a default_processor_chain"
+          end
+        else
+          Rails.logger.debug("#{self.class}##{__method__} received with an unknown initial parameter; caller: #{caller[0]}.  Best wishes on debugging.")
+          raise RuntimeError, "Expected #{args.first.inspect} to be an Array of symbols or an ActionController::Base, got #{args.first.class}"
+        end
+      end
+    end
+  end
+end
+
+Blacklight::AccessControls::SearchBuilder.prepend(Blacklight::AccessControls::SearchBuilderDecorator)

--- a/hydra/app/controllers/catalog_controller.rb
+++ b/hydra/app/controllers/catalog_controller.rb
@@ -2,6 +2,7 @@
 require 'blacklight/catalog'
 
 class CatalogController < ApplicationController
+  include BlacklightAdvancedSearch::Controller
 
   include Hydra::Catalog
   include BlacklightOaiProvider::Controller
@@ -9,6 +10,13 @@ class CatalogController < ApplicationController
   # before_action :enforce_show_permissions, only: :show
 
   configure_blacklight do |config|
+    # default advanced config values
+    config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
+    # config.advanced_search[:qt] ||= 'advanced'
+    config.advanced_search[:url_key] ||= 'advanced'
+    config.advanced_search[:query_parser] ||= 'dismax'
+    config.advanced_search[:form_solr_parameters] ||= {}
+
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
 
@@ -50,21 +58,22 @@ class CatalogController < ApplicationController
 
     # facet creator
     # Facets ---------------------------------------------
-    config.add_facet_field solr_name('date', :facetable), label: 'Date', limit: true, show: true, component: true
-    config.add_facet_field solr_name('creator', :facetable), label: 'Creator', limit: true, show: true, component: true
-    config.add_facet_field solr_name('contributing_institution', :facetable), label: 'Contributing Institution', link_to_search: :contributing_institution_ssi, limit: true, show: true, component: true
+    # Organized alphabetically - the ordering of the field names is the order of the display
     config.add_facet_field solr_name('collection_title', :facetable), label: 'Collection', link_to_search: :collection_title_ssi, limit: true, show: true, component: true
-    config.add_facet_field solr_name('publisher', :facetable), label: 'Publisher', link_to_search: :publisher_ssi, limit: true, show: true, component: true
-    config.add_facet_field solr_name('policy_area', :facetable), label: 'Policy Area', link_to_search: :policy_area_ssi, limit: true, show: true, component: true
-    config.add_facet_field solr_name('names', :facetable), label: 'Names', link_to_search: :names_ssi, limit: true, show: true, component: true    
-    config.add_facet_field solr_name('topic', :facetable), label: 'Topic', link_to_search: :topic_ssi, limit: true, show: true, component: true
     config.add_facet_field solr_name('congress', :facetable), label: 'Congress', link_to_search: :coverage_congress_ssi, limit: true, show: true, component: true
-    config.add_facet_field solr_name('physical_location', :facetable), label: 'Physical Location', link_to_search: :physical_location_ssi, limit: true, show: true, component: true
+    config.add_facet_field solr_name('contributing_institution', :facetable), label: 'Contributing Institution', link_to_search: :contributing_institution_ssi, limit: true, show: true, component: true
+    config.add_facet_field solr_name('creator', :facetable), label: 'Creator', limit: true, show: true, component: true
+    config.add_facet_field solr_name('date', :facetable), label: 'Date', limit: true, show: true, component: true
+    config.add_facet_field solr_name('extent', :facetable), label: 'Extent', limit: true, show: true, component: true
+    config.add_facet_field solr_name('language', :facetable), label: 'Language', limit: true, show: true, component: true
     config.add_facet_field solr_name('location_represented', :facetable), label: 'Location Represented', link_to_search: :coverage_spatial_ssi, limit: true, show: true, component: true
+    config.add_facet_field solr_name('names', :facetable), label: 'Names', link_to_search: :names_ssi, limit: true, show: true, component: true
+    config.add_facet_field solr_name('physical_location', :facetable), label: 'Physical Location', link_to_search: :physical_location_ssi, limit: true, show: true, component: true
+    config.add_facet_field solr_name('policy_area', :facetable), label: 'Policy Area', link_to_search: :policy_area_ssi, limit: true, show: true, component: true
+    config.add_facet_field solr_name('publisher', :facetable), label: 'Publisher', link_to_search: :publisher_ssi, limit: true, show: true, component: true
     config.add_facet_field solr_name('record_type', :facetable), label: 'Record Type', limit: true, show: true, component: true
     config.add_facet_field solr_name('rights', :facetable), label: 'Rights', limit: true, show: true, component: true
-    config.add_facet_field solr_name('language', :facetable), label: 'Language', limit: true, show: true, component: true
-    config.add_facet_field solr_name('extent', :facetable), label: 'Extent', limit: true, show: true, component: true
+    config.add_facet_field solr_name('topic', :facetable), label: 'Topic', link_to_search: :topic_ssi, limit: true, show: true, component: true
 
     # uses the above facets in blacklight
     #config.default_solr_params['facet.field'] = config.facet_fields.keys

--- a/hydra/app/controllers/saved_searches_controller.rb
+++ b/hydra/app/controllers/saved_searches_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SavedSearchesController < ApplicationController
+  include Blacklight::SavedSearches
+
+  helper BlacklightAdvancedSearch::RenderConstraintsOverride
+end

--- a/hydra/app/controllers/search_history_controller.rb
+++ b/hydra/app/controllers/search_history_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SearchHistoryController < ApplicationController
+  include Blacklight::SearchHistory
+
+  helper BlacklightAdvancedSearch::RenderConstraintsOverride
+end

--- a/hydra/app/models/search_builder.rb
+++ b/hydra/app/models/search_builder.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightAdvancedSearch::AdvancedSearchBuilder
+  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
 
   # Custom Processing of Holt only Records 
   # self.default_processor_chain += [:show_only_acda_records]

--- a/hydra/app/views/catalog/_search_form.html.erb
+++ b/hydra/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_tag search_action_url, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <div class="input-group">
+    <% if search_fields.length > 1 %>
+      <span class="input-group-addon for-search-field">
+        <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+        <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), title: t('blacklight.search.form.search_field.title'), id: "search_field", class: "search_field") %>
+      </span>
+    <% elsif search_fields.length == 1 %>
+      <%= hidden_field_tag :search_field, search_fields.first.last %>
+    <% end %>
+
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
+
+    <span class="input-group-btn">
+      <button type="submit" class="btn btn-primary search-btn" id="search">
+        <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
+        <span class="glyphicon glyphicon-search"></span>
+      </button>
+      <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-default'%>
+    </span>
+  </div>
+<% end %>

--- a/hydra/config/routes.rb
+++ b/hydra/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
   get '/featured' => 'featured#index'
   
   mount Blacklight::Engine => '/'
+  mount BlacklightAdvancedSearch::Engine => '/'
+
   root to: 'catalog#index'
     concern :searchable, Blacklight::Routes::Searchable.new
 


### PR DESCRIPTION
* 📚 Add documentation on building local containers

* 📚 Add dockermentation

* 🎁 Alphabetize facet list refs #106

Resequence list in catalog controller to sort facets alphabetically.

* 📚 Favor bullet point reference enumeration

* 📚 Document how to add content to app

Related to:

- https://github.com/scientist-softserv/west-virginia-university/issues/104



* ⚙️ Add blacklight_advanced_search gem

Once I added the `blacklight_advanced_search` gem, I ran the following:

```
docker compose exec web bundle
```

This added `blacklight_advanced_search` to the gem dependency graph by updating the `Gemfile.lock`

Related to:

- https://github.com/scientist-softserv/west-virginia-university/issues/98

* 🎁 Install blacklight_advanced_search

These files were generated via:

```
docker compose exec web rails generate blacklight_advanced_search:install
```

*Note:* The documentation said to run `rails generate blacklight_advanced_search`, however during the installation it mentioned that was deprecated in favor of the above.  So I reset and ran the command based on the guidance of the generator (figuring that guidance was likely more correct).

During the installation, the generator asked:

> Install local search form with advanced link? (y/N)

I answered `y`.

Related to:

- https://github.com/scientist-softserv/west-virginia-university/issues/98

* 💄 Move "More options" button beside Search

Prior to this commit, the "More Options" floated beneath the form; looking very much out of place.

With this change, it's inline and appropriate.

* ♻️ Add SearchBuilder#initialize parameter handler

Prior to this commit I was getting the following exception:

```
ArgumentError in AdvancedController#index
wrong number of arguments (given 2, expected 1; required keyword:
ability)
```

It turns out that during the AdvancedController#index request cycle we instantiate `Blacklight::AccessControls::SearchBuilder` multiple times; and with different parameter signatures.

Below are the logged calls of
`Blacklight::AccessControls::SearchBuilder`; note we have only minimal application changes so this appears to be a conflict between versions.

```
Blacklight::AccessControls::SearchBuilder#initialize with controller as first parameter; caller: /usr/local/bundle/gems/blacklight-access_controls-6.0.1/lib/blacklight/access_controls/catalog.rb:21:in `new'
Blacklight::AccessControls::SearchBuilder#initialize with processor_chain as first parameter; caller: /usr/local/bundle/gems/blacklight-6.25.0/lib/blacklight/search_builder.rb:81:in `new'
Blacklight::AccessControls::SearchBuilder#initialize with processor_chain as first parameter; caller: /usr/local/bundle/gems/blacklight-6.25.0/lib/blacklight/search_builder.rb:61:in `new'
```

With this commit, I'm introducing a crease in the code to re-arrange the method signature.  In doing so the exception mentioned above goes away, and I see the advanced search page.

Related to:

- https://github.com/scientist-softserv/west-virginia-university/issues/98

* Update DEVELOPMENT.md




---------

# Story

Refs:

- #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
