### PR TITLE
🐛 Prevent crash if no image

### DIFF
--- a/hydra/app/views/catalog/_document.html.erb
+++ b/hydra/app/views/catalog/_document.html.erb
@@ -14,7 +14,7 @@
 			<%= link_to_document document, render(:partial => 'audio_button'), class: "button audio-button" %>
 		<% elsif "Moving".in? document[:dc_type_ssi] %>
 			<%= link_to_document document, render(:partial => 'video_button'), class: "button video-button" %>
-		<% elsif Acda.where(identifier: identifier).first.image_file.nil? && document[:dc_type_ssi] == "Text" %>
+		<% elsif Acda.where(identifier: identifier).first&.image_file.nil? && document[:dc_type_ssi] == "Text" %>
 			<%= link_to_document document, render(:partial => 'pdf_button'), class: "button pdf-button" %>
 		<% else %>   
 			<%= link_to_document document, image_tag("/thumb/#{identifier}", title:"#{document[:title_ssi]}", alt:description) %>


### PR DESCRIPTION
# Story

Not all images created in my Bulkrax import, causing some views to crash. 

# Expected Behavior Before Changes

Error if works on view had no images

# Expected Behavior After Changes

View does not crash

# Screenshots / Video

<details>
<summary>Screenshots</summary>

## Before
![Screenshot 2023-10-19 at 11 58 35 AM](https://github.com/scientist-softserv/west-virginia-university/assets/17851674/7ece23ba-eeb0-4d2f-8dcb-45d6fd060944)


## After
![Screenshot 2023-10-19 at 11 59 16 AM](https://github.com/scientist-softserv/west-virginia-university/assets/17851674/9e1f5da9-4b54-4c29-b87a-ad934179cf20)

</details>

# Notes
