### PR TITLE
♻️ Skip merge commits for messages

### DIFF
--- a/bin/git-prm
+++ b/bin/git-prm
@@ -26,7 +26,7 @@ $stderr.puts `git checkout softserv-dev`
 $stderr.puts `git fetch origin`
 $stderr.puts `git fetch wvu`
 
-`git log --reverse --pretty="%H" wvu/softserv-dev..softserv-dev`.split("\n").each do |sha|
+`git log --reverse --pretty="%H" wvu/softserv-dev..softserv-dev --no-merges`.split("\n").each do |sha|
   next if SHAS_TO_SKIP_FOR_PULL_REQUEST_MESSAGE.include?(sha)
   puts `git log --pretty="format:## %s%n%n%H%n%n%b" #{sha}~..#{sha}`
   $stdout.puts ""


### PR DESCRIPTION
These commits are chatter that is not very useful when reviewing
changes.  The commits that are part of the merge are present, but the
"Merge changes" type commits are simply telling use a "point" in time
when the merge happens.