### PR TITLE
🧹 Remove date from advanced search

### DIFF
--- a/hydra/Gemfile
+++ b/hydra/Gemfile
@@ -26,6 +26,10 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # =====================================================
 gem 'blacklight_oai_provider'
 
+# Blacklight Range Limit for date searches
+# =====================================================
+gem 'blacklight_range_limit'
+
 # Automatic Import
 # =====================================================
 gem 'whenever', require: false
@@ -87,5 +91,4 @@ end
 group :development do
   gem 'web-console', '~> 3.0'
   gem 'spring', '< 4.0.0'
-  gem 'blacklight_range_limit'
 end

--- a/hydra/app/controllers/catalog_controller.rb
+++ b/hydra/app/controllers/catalog_controller.rb
@@ -65,13 +65,13 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('congress', :facetable), label: 'Congress', link_to_search: :coverage_congress_ssi, limit: true, show: true, component: true
     config.add_facet_field solr_name('contributing_institution', :facetable), label: 'Contributing Institution', link_to_search: :contributing_institution_ssi, limit: true, show: true, component: true
     config.add_facet_field solr_name('creator', :facetable), label: 'Creator', limit: true, show: true, component: true
-    config.add_facet_field solr_name('date', :facetable), label: 'Date', limit: true, show: true, component: true, range: {
+    config.add_facet_field solr_name('date', :facetable), include_in_advanced_search: false, label: 'Date', limit: true, show: true, component: true, range: {
       facet_field_label: 'Date Range',
       num_segments: 10,
       assumed_boundaries: [1100, Time.zone.now.year + 2],
       segments: false,
       slider_js: false,
-      maxlength: 4
+      maxlength: 10
     }
     config.add_facet_field solr_name('extent', :facetable), label: 'Extent', limit: true, show: true, component: true
     config.add_facet_field solr_name('language', :facetable), label: 'Language', limit: true, show: true, component: true


### PR DESCRIPTION
There is a known issue with the date facet in advanced search and the common approach is to remove it.  This commit will remove the date from the advanced search form and also increase the character limit for the form fields.  It was set to 4 but that was only enough for the year and didn't work for a date search like DD/MM/YYYY.  Lastly, I moved the gem call for `blacklight_range_limit` out of the development group so it can be used in a deployed environment.  Other than those changes, the search seems to be working as expected

Ref:
  - https://github.com/scientist-softserv/west-virginia-university/issues/100
  - https://github.com/LafayetteCollegeLibraries/spot/pull/143

# Expected Behavior Before Changes
Filtered advanced searches generally work as intended as the results show up in the catalog search view just like a regular search.  However, the actual `Search` button does not work.  It does work if you hit `enter` or `return` on your keyboard though.  This is because it conflicts with the Blacklight Range Limit gem in that the Date facet also has a form element so it becomes a nested form tag which does some funky rendering.

# Expected Behavior After Changes
Filtered advanced searches should still work but the Date facet is omitted so it doesn't cause conflicts.  Date searches on the regular search is not just limited to 4 characters anymore.

# Screenshots / Video

### Before:
https://github.com/scientist-softserv/west-virginia-university/assets/19597776/488cac37-b0c1-4e36-b2d2-facf2c812f8b

### After:
https://github.com/scientist-softserv/west-virginia-university/assets/19597776/9ec99696-c7c6-4459-bf97-0d9ff8237288

