### PR TITLE
🐛 Correct Logic causing import errors

### DIFF
--- a/hydra/app/factories/bulkrax/acda_factory.rb
+++ b/hydra/app/factories/bulkrax/acda_factory.rb
@@ -43,9 +43,9 @@ module Bulkrax
 
     def run!
       @object = find
-
+      
       object.present? ? update : create
-      raise ActiveFedora::RecordInvalid, object if !object.persisted? || object.changed?
+      raise ActiveFedora::RecordInvalid, object unless object.persisted? || object.changed?
 
       object
     end


### PR DESCRIPTION
The current logic would cause ActiveFedora::RecordInvalid errors when importing via bulkrax. This commit corrects the logic.

Issue:
- https://github.com/scientist-softserv/west-virginia-university/issues/104


# Expected Behavior Before Changes

![image](https://github.com/scientist-softserv/west-virginia-university/assets/10081604/e22e50bb-1531-4ac2-93db-f4148f67be4d)


# Expected Behavior After Changes

![Screenshot 2023-10-24 at 12-55-44 American Congress Digital Archives Portal](https://github.com/scientist-softserv/west-virginia-university/assets/10081604/86bc87f2-bc91-47a2-9fc6-1554c42f2c2e)


