### PR TITLE
🎁 Add primary/secondary terms to advanced search

### DIFF
--- a/hydra/app/assets/javascripts/advanced_search_additional_fields.js
+++ b/hydra/app/assets/javascripts/advanced_search_additional_fields.js
@@ -1,0 +1,8 @@
+// Allows the `Additional fields` button on the advanced search page
+// to toggle the additional fields div on and off.
+$(document).ready(function() {
+  $('.additional-fields').click(function(e) {
+    e.preventDefault();
+    $('#additionalFieldsDiv').collapse('toggle');
+  });
+});

--- a/hydra/app/assets/javascripts/application.js
+++ b/hydra/app/assets/javascripts/application.js
@@ -14,8 +14,11 @@
 // Rails or Hydra Requirements
 // -----------------------------------------------------
 //= require jquery
-//= require 'blacklight_advanced_search'
 
+// Required by Blacklight Advance Search
+// -----------------------------------------------------
+//= require 'blacklight_advanced_search'
+//= require advanced_search_additional_fields
 
 //= require jquery_ujs
 //= require bootstrap
@@ -42,4 +45,3 @@
 // For blacklight_range_limit built-in JS, if you don't want it you don't need
 // this:
 //= require 'blacklight_range_limit'
-

--- a/hydra/app/assets/stylesheets/blacklight_advanced_search.scss
+++ b/hydra/app/assets/stylesheets/blacklight_advanced_search.scss
@@ -2,7 +2,7 @@
     Style overrides for Blacklight Advanced Search page
 **********************************************************************/
 
-#advanced_search > div > div > input.form-control {
+.query-criteria input.form-control {
   color: black;
 }
 

--- a/hydra/app/controllers/catalog_controller.rb
+++ b/hydra/app/controllers/catalog_controller.rb
@@ -142,7 +142,24 @@ class CatalogController < ApplicationController
     # add the search fields individually from solr
     # use this as a template for creating new ones
     # Search ---------------------------------------------
-    default_search_fields = ['identifier', 'title', 'date', 'contributing_institution', 'policy_area', 'names', 'topic', 'congress', 'physical_location', 'location_represented', 'record_type', 'rights', 'language', 'extent']
+    default_search_fields = %w[
+      creator
+      date
+      names
+      title
+      collection_title
+      congress
+      contributing_institution
+      description
+      identifier
+      language
+      location_represented
+      policy_area
+      publisher
+      record_type
+      rights
+      topic
+    ]
     default_search_fields.map! { |f|
       config.add_search_field(f.to_s) do |field|
           field.solr_parameters = {

--- a/hydra/app/helpers/blacklight/advanced_search_helper.rb
+++ b/hydra/app/helpers/blacklight/advanced_search_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Blacklight
+  # Helpers related to the advanced search functionality of Blacklight.
+  module AdvancedSearchHelper
+    # Adjust number to show more or less primary fields in the advanced search form.
+    NUMBER_OF_PRIMARY_FIELDS = 4
+
+    # Retrieves the first four search fields from a given collection.
+    #
+    # @param fields [Array] collection of search fields
+    # @return [Array] a subset of the input collection containing the first four fields
+    def primary_search_fields_for(fields)
+      fields.each_with_index.partition { |_, idx| idx < NUMBER_OF_PRIMARY_FIELDS }.first.map(&:first)
+    end
+
+    # Retrieves all search fields from a given collection except the first four.
+    #
+    # @param fields [Array] collection of search fields
+    # @return [Array] a subset of the input collection excluding the first four fields
+    def secondary_search_fields_for(fields)
+      fields.each_with_index.partition { |_, idx| idx < NUMBER_OF_PRIMARY_FIELDS }.last.map(&:first)
+    end
+  end
+end

--- a/hydra/app/views/advanced/_advanced_search_fields.html.erb
+++ b/hydra/app/views/advanced/_advanced_search_fields.html.erb
@@ -1,0 +1,26 @@
+<%
+  # OVERRIDE blacklight_advanced_search v6.4.1 to split the primary and secondary fields
+  # See: CatalogController#search_fields_without_customization=
+  # See: Blacklight::BlacklightHelperBehavior#primary_search_fields, #secondary_search_fields
+%>
+<%- primary_search_fields_for(search_fields_for_advanced_search).each do |key, field_def| -%>
+  <div class="form-group advanced-search-field">
+      <%= label_tag key, "#{field_def.label}", :class => "col-sm-3 control-label" %>
+      <div class="col-sm-9">
+        <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+      </div>
+  </div>
+<%- end -%>
+
+<a class="btn btn-default additional-fields pull-right collapsed" id="advanced-search-additional-fields" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="additionalFieldsDiv" href="#additionalFieldsDiv">Additional fields</a><br /><br /><br />
+
+<div id="additionalFieldsDiv" class="collapse" aria-expanded="false">
+  <%- secondary_search_fields_for(search_fields_for_advanced_search).each do |key, field_def| -%>
+    <div class="form-group advanced-search-field">
+        <%= label_tag key, "#{field_def.label}", :class => "col-sm-3 control-label" %>
+        <div class="col-sm-9">
+          <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+        </div>
+    </div>
+  <%- end -%>
+</div>

--- a/hydra/spec/helpers/blacklight/advanced_search_helper_spec.rb
+++ b/hydra/spec/helpers/blacklight/advanced_search_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Blacklight::AdvancedSearchHelper do
+  include described_class
+
+  let(:search_fields_for_advanced_search) { CatalogController.blacklight_config.search_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? } }
+
+  describe "#primary_search_fields" do
+    it "returns the primary search fields" do
+      expect(primary_search_fields_for(search_fields_for_advanced_search).size).to eq(Blacklight::AdvancedSearchHelper::NUMBER_OF_PRIMARY_FIELDS)
+    end
+
+    it "returns the client specified advanced search fields" do
+      expect(primary_search_fields_for(search_fields_for_advanced_search).map { |search| search.last.key }).to eq(["creator", "date", "names", "title"])
+    end
+  end
+
+  describe "#secondary_search_fields" do
+    it "returns the secondary search fields" do
+      second_search_fields_count = search_fields_for_advanced_search.size - Blacklight::AdvancedSearchHelper::NUMBER_OF_PRIMARY_FIELDS
+
+      expect(secondary_search_fields_for(search_fields_for_advanced_search).size).to eq(second_search_fields_count)
+    end
+  end
+end


### PR DESCRIPTION
# Story

This commit will add the ability to add primary and secondary terms to the advanced search form.  Currently on the first four terms are shown which can be adjusted at:

`Blacklight::AdvancedSearchHelper::NUMBER_OF_PRIMARY_FIELDS`

Ref:
  - https://github.com/scientist-softserv/west-virginia-university/issues/99

# Expected Behavior Before Changes
Advanced search page was just the default view.

# Expected Behavior After Changes
Customized the advanced search page into showing primary and secondary terms

# Screenshots / Video

https://github.com/scientist-softserv/west-virginia-university/assets/19597776/26b81cb8-cc15-49ef-b108-15199a0b0aa2
