### PR TITLE
🎁 Add new bulkrax delimiter splitting

### DIFF
--- a/hydra/app/models/acda.rb
+++ b/hydra/app/models/acda.rb
@@ -59,7 +59,7 @@ class Acda < ActiveFedora::Base
   # DC date
   # ==============================================================================================================
   # date property
-  property :date, predicate: ::RDF::Vocab::DC.date, multiple: false do |index|
+  property :date, predicate: ::RDF::Vocab::DC.date, multiple: true do |index|
     index.as :stored_searchable, :stored_sortable, :facetable
   end
 
@@ -74,7 +74,7 @@ class Acda < ActiveFedora::Base
   # DC creator
   # ==============================================================================================================
   # creator property
-  property :creator, predicate: ::RDF::Vocab::DC.creator, multiple: false do |index|
+  property :creator, predicate: ::RDF::Vocab::DC.creator, multiple: true do |index|
     index.as :stored_searchable, :stored_sortable, :facetable
   end
 
@@ -95,7 +95,7 @@ class Acda < ActiveFedora::Base
   # DC temporal
   # ==============================================================================================================
   # congress property
-  property :congress, predicate: ::RDF::Vocab::DC.temporal, multiple: false do |index|
+  property :congress, predicate: ::RDF::Vocab::DC.temporal, multiple: true do |index|
     index.as :stored_searchable, :stored_sortable, :facetable
   end
 

--- a/hydra/app/models/solr_document.rb
+++ b/hydra/app/models/solr_document.rb
@@ -19,7 +19,7 @@ class SolrDocument
   field_semantics.merge!(
     contributing_institution: 'contributing_institution_tesim',
     title: 'title_tesim',
-    date: 'edtf_tesim',
+    date: 'date_tesim',
     edtf: 'edtf_tesim',
     creator: 'creator_tesim',
     rights: 'rights_tesim',

--- a/hydra/config/initializers/bulkrax.rb
+++ b/hydra/config/initializers/bulkrax.rb
@@ -45,12 +45,12 @@ Bulkrax.setup do |config|
     'Bulkrax::CsvParser' => {
       'contributing_institution' => { from: ['dcterms:provenance'] },
       'title' => { from: ['dcterms:title'] },
-      'date' => { from: ['dcterms:date'] },
+      'date' => { from: ['dcterms:date'], split: true },
       'edtf' => { from: ['dcterms:created'] },
-      'creator' => { from: ['dcterms:creator'] },
+      'creator' => { from: ['dcterms:creator'], split: true },
       'rights' => { from: ['dcterms:rights'] },
       'language' => { from: ['dcterms:language'], split: true },
-      'congress' => { from: ['dcterms:temporal'] },
+      'congress' => { from: ['dcterms:temporal'], split: true },
       'collection_title' => { from: ['dcterms:relation'] },
       'physical_location' => { from: ['dcterms:isPartOf'] },
       'collection_finding_aid' => { from: ['dcterms:source'] },
@@ -63,7 +63,8 @@ Bulkrax.setup do |config|
       'names' => { from: ['dcterms:contributor'], split: true },
       'dc_type' => { from: ['dcterms:type'] },
       'record_type' => { from: ['dcterms:http://purl.org/dc/terms/type'], split: true },
-      'format' => { from: ['dcterms:format'] },
+      'location_represented' => { from: ['dcterms:spatial'], split: true },
+      'extent' => { from: ['dcterms:format'] },
       'publisher' => { from: ['dcterms:publisher'], split: true },
       'policy_area' => { from: ['dcterms:subject'], split: true }
     }


### PR DESCRIPTION
# Story

refs:
https://github.com/scientist-softserv/west-virginia-university/issues/134

**New features:** 🎁
- split import of dcterms:date on delimiter
- split import of dcterms:temporal on delimiter
- split import of dcterms:creator on delimiter
- Add dcterms:spatial to bulkrax mapping and split on delimiter 

**Bug fixes:** 🐛
- Map dcterms:format into extent: extent now imports
- fix field_semantics mapping for date: date now includes correct info for xml & csv search exports

# Expected Behavior Before Changes

Terms did not split on bulkrax import: `date`, `temporal`, `creator`
Term was not imported via bulkrax: `spatial`, `extent`

# Expected Behavior After Changes

- Bulkrax imports multiple values, separated by `;` for `dcterms:date`, `dcterms:temporal`, `dcterms:creator`, and `dcterms:spatial`.
- `Location Represented` and `Extent` now import and appear on the show page.

# Screenshots / Video

<details>
<summary>Screenshots</summary>

## Date splits on delimiter
![Screenshot 2023-10-26 at 5 23 47 PM](https://github.com/scientist-softserv/west-virginia-university/assets/17851674/28498294-902c-4b92-a4ab-eadedfa292ca)

## Creator splits on delimiter
![Screenshot 2023-10-26 at 5 22 45 PM](https://github.com/scientist-softserv/west-virginia-university/assets/17851674/30070b6c-11de-4ed0-a59a-1ede7d14361f)

## Temporal/Congress splits on delimiter
![Screenshot 2023-10-26 at 5 26 09 PM](https://github.com/scientist-softserv/west-virginia-university/assets/17851674/a570cb1d-b014-469f-a236-667a16647942)

## Location Represented/Spatial splits on delimiter
![Screenshot 2023-10-26 at 5 26 49 PM](https://github.com/scientist-softserv/west-virginia-university/assets/17851674/7ab24ce6-18f5-4541-9db9-8ee57061fa6c)

</details>

# Notes