### PR TITLE
🎁 Allows user to import identifiers with protocols and domains

### DIFF
--- a/hydra/app/models/acda.rb
+++ b/hydra/app/models/acda.rb
@@ -39,7 +39,14 @@ class Acda < ActiveFedora::Base
   # Minting ID
   # Overriding Fedoras LONG URI NOT FRIENDLY ID
   def assign_id
-    identifier.gsub('.', '').to_s
+    # Removes the protocol (http or https) and domain part of the url
+    cleaned_identifier = identifier.gsub(/https?:\/\/[^\/]+\//, '')
+
+    # Removes special characters typically found in urls
+    cleaned_identifier = cleaned_identifier.gsub(/[\/:?%&=#+_]/, '_')
+
+    # Replaces periods with empty strings to maintain the original functionality
+    cleaned_identifier.gsub('.', '').to_s
   end
 
   # DC provenance

--- a/hydra/spec/models/acda_spec.rb
+++ b/hydra/spec/models/acda_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Acda, type: :model do
+  let(:acda) { Acda.new }
+
+  describe '#assign_id' do
+    it 'returns a cleaned identifier for a uri with special characters' do
+      acda.identifier = 'http://www.example.com:8080/path/to/resource.html?id=123&name=test_name#section_1?extra=10%25+off'
+      expect(acda.assign_id).to eq('path_to_resourcehtml_id_123_name_test_name_section_1_extra_10_25_off')
+    end
+
+    it 'returns a cleaned identifier for .mp3' do
+      acda.identifier = 'c016_k001_a.mp3'
+      expect(acda.assign_id).to eq('c016_k001_amp3')
+    end
+  end
+end


### PR DESCRIPTION
# Summary

A user cannot import when the identifier is a uri. 

Issue: 
- https://github.com/scientist-softserv/west-virginia-university/issues/140

# Screenshots / Video

## BEFORE 

![image](https://github.com/scientist-softserv/west-virginia-university/assets/10081604/24c29f83-b9f6-43e4-8ca2-3d4be2750377)



## AFTER - the record was successfully created

![image (39)](https://github.com/wvulibraries/hydra_acda_portal_public/assets/10081604/8af0cf25-b6aa-4cd8-b01f-ed33901abb8d)

# Expected Behavior

a user should be able to import an identifier as a uri, like: 'http://hdl.handle.net/10524/63351'

# Notes


