### PR TITLE
🐛 Fix CSV/XML identifier export

### DIFF
--- a/hydra/app/models/solr_document.rb
+++ b/hydra/app/models/solr_document.rb
@@ -12,7 +12,16 @@ class SolrDocument
 
     @semantic_value_hash ||= {}
     idno = @semantic_value_hash[:identifier].first
-    @semantic_value_hash[:identifier] = "http://congressarchivesdev.lib.wvu.edu/record/#{idno}"
+
+    # Check if the identifier is a URL
+    if url?(idno)
+      # accounts for something like http://hdl.handle.net/123/123 being the identifier
+      # we wouldn't want to prepend our URL in that case
+      @semantic_value_hash[:identifier] = idno
+    else
+      @semantic_value_hash[:identifier] = "http://congressarchivesdev.lib.wvu.edu/record/#{idno}"
+    end
+
     @semantic_value_hash
   end
 
@@ -39,9 +48,9 @@ class SolrDocument
     extent: 'extent_tesim',
     publisher: 'publisher_tesim',
     description: 'description_tesim',
-    dc_type: 'dc_type_tesim',    
+    dc_type: 'dc_type_tesim',
     project: 'project_tesim',
-    bulkrax_identifier: 'bulkrax_identifier_tesim'   
+    bulkrax_identifier: 'bulkrax_identifier_tesim'
   )
 
   # self.unique_key = 'id'
@@ -59,11 +68,18 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
-  # Do content negotiation for AF models. 
+  # Do content negotiation for AF models.
   use_extension( Hydra::ContentNegotiation )
 
-  # Sets 
+  # Sets
   def sets
     fetch('language', []).map { |l| BlacklightOaiProvider::Set.new("language:#{l}") }
   end
+
+  private
+
+    # Check if a given string is a URL
+    def url?(str)
+      str =~ /\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/
+    end
 end

--- a/hydra/app/views/catalog/_export_search_results.html.erb
+++ b/hydra/app/views/catalog/_export_search_results.html.erb
@@ -1,12 +1,10 @@
 <div id="export-results" class="btn-group">
-  <% params.delete('page') %>
-
   <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
     Export <span class="caret"></span>
   </button>
 
   <ul class="dropdown-menu">
-    <li><%= link_to "Export to CSV", catalog_export_path(rows: @response.total, format: :csv) %></li>
-    <li><%= link_to "Export to XML", catalog_export_path(rows: @response.total, format: :xml) %></li>
+    <li><%= link_to "Export to CSV", catalog_export_path(rows: @response.total, format: :csv, q: params[:q]) %></li>
+    <li><%= link_to "Export to XML", catalog_export_path(rows: @response.total, format: :xml, q: params[:q]) %></li>
   </ul>
 </div>


### PR DESCRIPTION
# Story

This commit fixes a couple of bugs where if the identifier is a URI, it gets exported weird because of the logic of prepending http://congressarchivesdev.lib.wvu.edu/record/ to the identifier.  Also, a bug was discovered where the query param was not being passed to the export method, so the export was always whatever was a no q="" kind of export.

Ref:
  - https://github.com/scientist-softserv/west-virginia-university/issues/93
  - https://github.com/scientist-softserv/west-virginia-university/issues/94

# Screenshots / Video

<img width="983" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/b64188d2-608a-4395-9a81-e4e0c8ccc382">
<img width="962" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/1415dcd3-0089-47ab-a7d4-88f905a8748f">

