### PR TITLE
I113 Update Chicago Citation Service per requirements

### DIFF
--- a/hydra/app/services/chicago_citation_service.rb
+++ b/hydra/app/services/chicago_citation_service.rb
@@ -4,18 +4,16 @@ module ChicagoCitationService
       # format is based off of https://www.loc.gov/programs/teachers/getting-started-with-primary-sources/citing/chicago/
       text = ""
 
-      creator = sanitize_value(document['creator_tesim']&.first)
-      title = sanitize_value(document['title_tesim']&.first || document['description_tesim']&.first)
-      date = sanitize_value(document['date_tesim']&.first)
-      location = sanitize_value(physical_location(document))
-      contributing_institution = sanitize_value(document['contributing_institution_tesim']&.first)
+      title = sanitize_value(document['title_ssi'] || document['description_ssi'])
+      date = sanitize_value(document['date_ssi'])
+      location = sanitize_value(document['physical_location_ssi'])
+      contributing_institution = sanitize_value(document['contributing_institution_ssi'])
       url = original_url
       access_date = Date.today.strftime("%B %d, %Y")
 
-      text << "#{creator}. " if creator.present?
-      text << "<i>#{title}</i>. " if title.present?
-      text << "#{date}. " if date.present?
-      text << "#{location}. " if location.present?
+      text << "<i>#{title}</i>, " if title.present?
+      text << "#{date}, " if date.present?
+      text << "#{location}, " if location.present?
       text << "#{contributing_institution}. " if contributing_institution.present?
       text << "#{url}"
       text << " (accessed #{access_date})."
@@ -26,35 +24,18 @@ module ChicagoCitationService
     private
 
       def collection_number(doc)
-        match = doc['physical_location_tesim']&.first&.match(/collection (\d+)/i)
+        match = doc['physical_location_ssi']&.match(/collection (\d+)/i)
         match ? match[1] : nil
       end
 
       def box_number(doc)
-        match = doc['physical_location_tesim']&.first&.match(/box (\d+)/i)
+        match = doc['physical_location_ssi']&.match(/box (\d+)/i)
         match ? match[1] : nil
       end
 
       def folder_number(doc)
-        match = doc['physical_location_tesim']&.first&.match(/folder (\d+)/i)
+        match = doc['physical_location_ssi']&.match(/folder (\d+)/i)
         match ? match[1] : nil
-      end
-
-      def physical_location(doc)
-        collection = collection_number(doc)
-        box = box_number(doc)
-        folder = folder_number(doc)
-
-        if collection || box || folder
-          location = ""
-          location << "Collection #{collection}, " if collection
-          location << "Box #{box}, " if box
-          location << "Folder #{folder}" if folder
-
-          location.strip.chomp(',')
-        else
-          doc['physical_location_tesim']&.first
-        end
       end
 
       def sanitize_value(value)

--- a/hydra/app/services/chicago_citation_service.rb
+++ b/hydra/app/services/chicago_citation_service.rb
@@ -4,18 +4,16 @@ module ChicagoCitationService
       # format is based off of https://www.loc.gov/programs/teachers/getting-started-with-primary-sources/citing/chicago/
       text = ""
 
-      creator = sanitize_value(document['creator_tesim']&.first)
-      title = sanitize_value(document['title_tesim']&.first || document['description_tesim']&.first)
-      date = sanitize_value(document['date_tesim']&.first)
-      location = sanitize_value(physical_location(document))
-      contributing_institution = sanitize_value(document['contributing_institution_tesim']&.first)
+      title = sanitize_value(document['title_ssi'] || document['description_ssi'])
+      date = sanitize_value(document['date_ssi'])
+      location = sanitize_value(document['physical_location_ssi'])
+      contributing_institution = sanitize_value(document['contributing_institution_ssi'])
       url = original_url
       access_date = Date.today.strftime("%B %d, %Y")
 
-      text << "#{creator}. " if creator.present?
-      text << "<i>#{title}</i>. " if title.present?
-      text << "#{date}. " if date.present?
-      text << "#{location}. " if location.present?
+      text << "<i>#{title}</i>, " if title.present?
+      text << "#{date}, " if date.present?
+      text << "#{location}, " if location.present?
       text << "#{contributing_institution}. " if contributing_institution.present?
       text << "#{url}"
       text << " (accessed #{access_date})."
@@ -24,38 +22,6 @@ module ChicagoCitationService
     end
 
     private
-
-      def collection_number(doc)
-        match = doc['physical_location_tesim']&.first&.match(/collection (\d+)/i)
-        match ? match[1] : nil
-      end
-
-      def box_number(doc)
-        match = doc['physical_location_tesim']&.first&.match(/box (\d+)/i)
-        match ? match[1] : nil
-      end
-
-      def folder_number(doc)
-        match = doc['physical_location_tesim']&.first&.match(/folder (\d+)/i)
-        match ? match[1] : nil
-      end
-
-      def physical_location(doc)
-        collection = collection_number(doc)
-        box = box_number(doc)
-        folder = folder_number(doc)
-
-        if collection || box || folder
-          location = ""
-          location << "Collection #{collection}, " if collection
-          location << "Box #{box}, " if box
-          location << "Folder #{folder}" if folder
-
-          location.strip.chomp(',')
-        else
-          doc['physical_location_tesim']&.first
-        end
-      end
 
       def sanitize_value(value)
         Loofah.fragment(value.to_s).scrub!(:strip).to_s

--- a/hydra/spec/services/chicago_citation_service_spec.rb
+++ b/hydra/spec/services/chicago_citation_service_spec.rb
@@ -11,17 +11,16 @@ RSpec.describe ChicagoCitationService do
     context 'when all fields are present' do
       let(:attributes) do
         {
-          'creator_tesim' => ['Creator'],
-          'title_tesim' => ['Title'],
-          'date_tesim' => ['Date'],
-          'physical_location_tesim' => ['Physical Location'],
-          'contributing_institution_tesim' => ['Contributing Institution']
+          'title_ssi' => 'Title',
+          'date_ssi' => 'Date',
+          'physical_location_ssi' => 'Physical Location',
+          'contributing_institution_ssi' => 'Contributing Institution'
         }
       end
 
       it 'returns a formatted citation' do
         expect(service.format(document: doc, original_url: url)).to eq(
-          "Creator. <i>Title</i>. Date. Physical Location. Contributing Institution. https://www.wvu.edu/catalog/1234 (accessed #{access_date})."
+          "<i>Title</i>, Date, Physical Location, Contributing Institution. https://www.wvu.edu/catalog/1234 (accessed #{access_date})."
         )
       end
     end
@@ -29,16 +28,16 @@ RSpec.describe ChicagoCitationService do
     context 'when url is not present' do
       let(:attributes) do
         {
-          'title_tesim' => ['Title'],
-          'date_tesim' => ['Date'],
-          'physical_location_tesim' => ['Physical Location'],
-          'contributing_institution_tesim' => ['Contributing Institution']
+          'title_ssi' => 'Title',
+          'date_ssi' => 'Date',
+          'physical_location_ssi' => 'Physical Location',
+          'contributing_institution_ssi' => 'Contributing Institution'
         }
       end
 
       it 'returns a formatted citation' do
         expect(service.format(document: doc, original_url: url)).to eq(
-          "<i>Title</i>. Date. Physical Location. Contributing Institution. https://www.wvu.edu/catalog/1234 (accessed #{access_date})."
+          "<i>Title</i>, Date, Physical Location, Contributing Institution. https://www.wvu.edu/catalog/1234 (accessed #{access_date})."
         )
       end
     end


### PR DESCRIPTION
In this commit we are making adjustments to the Chicago Citation Service to make the requirements specified by the client.

ref:
- https://github.com/scientist-softserv/west-virginia-university/issues/113#issuecomment-1783385472

# Expected Behavior Before Changes

 1. the citation still seems to be pulling from the dcterms:creator field (see above), which we can get rid of. No name is necessary.
2. title is correctly mapped to dcterms:title field
3. date is correctly mapped to dcterms:created field
4. Collection/Box/Folder information seems to be truncated, only showing part of the dcterms:ispartof field instead the entire contents (see attached screengrab, it's only saying 'Folder 56' but the field reads MANUSCRIPT-HCPC00011, Speeches, Box SP7, Folder 56 in physical location metadata to left)
5. there should be a comma after each field up until dcterms:provenance, not a period.
6. period after dcterms:provenance field is correct
7. period after url is correct

![image](https://github.com/scientist-softserv/west-virginia-university/assets/10081604/f437ebc3-2f7e-4e18-abe0-0f2998a7d12e)


# Expected Behavior After Changes

![Screenshot 2023-10-27 at 13-31-16 Social Security Rescued Press Release and Newsletter - American Congress Digital Archives Portal](https://github.com/scientist-softserv/west-virginia-university/assets/10081604/76acb4e1-74e5-4304-969f-d1e896633e7a)


- [X]  1. the citation still seems to be pulling from the dcterms:creator field (see above), which we can get rid of. No name is necessary.
- [X] 2. title is correctly mapped to dcterms:title field
- [X] 3. date is correctly mapped to dcterms:created field
- [X] 4. Collection/Box/Folder information seems to be truncated, only showing part of the dcterms:ispartof field instead the entire contents (see attached screengrab, it's only saying 'Folder 56' but the field reads MANUSCRIPT-HCPC00011, Speeches, Box SP7, Folder 56 in physical location metadata to left)
- [X] 5. there should be a comma after each field up until dcterms:provenance, not a period.
- [X] 6. period after dcterms:provenance field is correct
- [X] 7. period after url is correct