### PR TITLE
🎁 Modify the way date range limits work

### DIFF
--- a/hydra/app/assets/stylesheets/date_facet_range.scss
+++ b/hydra/app/assets/stylesheets/date_facet_range.scss
@@ -2,10 +2,6 @@
     Style overrides for Blacklight Range Limit partial
 **********************************************************************/
 
-#range_date_sim_begin {
-  color: black;
-}
-
-#range_date_sim_end {
-  color: black;
+.range_limit  input {
+  color: #333
 }

--- a/hydra/app/controllers/catalog_controller.rb
+++ b/hydra/app/controllers/catalog_controller.rb
@@ -65,13 +65,13 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('congress', :facetable), label: 'Congress', link_to_search: :coverage_congress_ssi, limit: true, show: true, component: true
     config.add_facet_field solr_name('contributing_institution', :facetable), label: 'Contributing Institution', link_to_search: :contributing_institution_ssi, limit: true, show: true, component: true
     config.add_facet_field solr_name('creator', :facetable), label: 'Creator', limit: true, show: true, component: true
-    config.add_facet_field solr_name('date', :facetable), include_in_advanced_search: false, label: 'Date', limit: true, show: true, component: true, range: {
+    config.add_facet_field 'date_ssi', include_in_advanced_search: false, label: 'Date', limit: true, show: true, component: true, range: {
       facet_field_label: 'Date Range',
       num_segments: 10,
       assumed_boundaries: [1100, Time.zone.now.year + 2],
       segments: false,
       slider_js: false,
-      maxlength: 10
+      maxlength: 4
     }
     config.add_facet_field solr_name('extent', :facetable), label: 'Extent', limit: true, show: true, component: true
     config.add_facet_field solr_name('language', :facetable), label: 'Language', limit: true, show: true, component: true

--- a/hydra/app/indexers/indexer.rb
+++ b/hydra/app/indexers/indexer.rb
@@ -1,0 +1,18 @@
+class Indexer < ActiveFedora::IndexingService
+  def generate_solr_document
+    super.tap do |solr_doc|
+      add_date(solr_doc)
+    end
+  end
+
+  private
+
+    def add_date(solr_doc)
+      # The allowed date formats are either YYYY, YYYY-MM, or YYYY-MM-DD
+      # the date must be formatted as a 4 digit year in order to be sorted.
+      valid_date_formats = /\A(\d{4})(?:-\d{2}(?:-\d{2})?)?\z/
+      date_string = solr_doc['edtf_ssi']
+      year = date_string&.match(valid_date_formats)&.captures&.first
+      solr_doc['date_ssi'] = year if year
+    end
+end

--- a/hydra/app/models/acda.rb
+++ b/hydra/app/models/acda.rb
@@ -7,6 +7,8 @@ class Acda < ActiveFedora::Base
   after_create :generate_thumbnail
   after_save :clear_empty_fields
 
+  self.indexer = Indexer
+
   def generate_thumbnail
     # queue job to generate thumbnail
     GenerateThumbsJob.perform_later(identifier)

--- a/hydra/app/services/chicago_citation_service.rb
+++ b/hydra/app/services/chicago_citation_service.rb
@@ -4,10 +4,10 @@ module ChicagoCitationService
       # format is based off of https://www.loc.gov/programs/teachers/getting-started-with-primary-sources/citing/chicago/
       text = ""
 
-      title = sanitize_value(document['title_ssi'] || document['description_ssi'])
-      date = sanitize_value(document['date_ssi'])
-      location = sanitize_value(document['physical_location_ssi'])
-      contributing_institution = sanitize_value(document['contributing_institution_ssi'])
+      title = sanitize_value(document['title_tesim']&.first || document['description_tesim']&.first)
+      date = sanitize_value(document['date_tesim']&.first)
+      location = sanitize_value(document['physical_location_tesim']&.first)
+      contributing_institution = sanitize_value(document['contributing_institution_tesim']&.first)
       url = original_url
       access_date = Date.today.strftime("%B %d, %Y")
 

--- a/hydra/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/hydra/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -1,0 +1,106 @@
+<%#
+  OVERRIDE blacklight_range_limit gem to alter the look and text
+%>
+
+<%- # requires solr_config local passed in
+  field_config = range_config(field_name)
+  label = facet_field_label(field_name)
+
+  input_label_range_begin = field_config[:input_label_range_begin] || t("blacklight.range_limit.range_begin", field_label: label)
+  input_label_range_end   = field_config[:input_label_range_end] || t("blacklight.range_limit.range_end", field_label: label)
+  maxlength = field_config[:maxlength]
+-%>
+
+<div class="limit_content range_limit">
+  <% if has_selected_range_limit?(field_name) %>
+    <ul class="current list-unstyled facet-values">
+      <li class="selected">
+        <span class="facet-label">
+          <span class="selected"><%= range_display(field_name) %></span>
+           <%= link_to remove_range_param(field_name), :class=>"remove", :title => t('blacklight.range_limit.remove_limit') do %>
+            <span class="glyphicon glyphicon-remove"></span>
+            <span class="sr-only">[<%= t('blacklight.range_limit.remove_limit') %>]</span>
+           <% end %>
+        </span>
+        <span class="selected facet-count"><%= number_with_delimiter(@response.total) %></span>
+      </li>
+    </ul>
+
+  <% end %>
+
+  <% unless selected_missing_for_range_limit?(field_name) %>
+    <%= form_tag search_action_path, :method => :get, class: [BlacklightRangeLimit.classes[:form], "range_#{field_name}"].join(' ') do %>
+      <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:page)) %>
+
+      <!-- we need to include a dummy search_field parameter if none exists,
+           to trick blacklight into displaying actual search results instead
+           of home page. Not a great solution, but easiest for now. -->
+      <% unless params.has_key?(:search_field) %>
+        <%= hidden_field_tag("search_field", "dummy_range") %>
+      <% end %>
+
+      <%# OVERRIDE begin %>
+      <div class="range_input_wrapper mt-2">
+        <div class="year-input">Between year:</div>
+        <%= render_range_input(field_name, :begin, input_label_range_begin, maxlength) %>
+      </div>
+
+      <div class="range_input_wrapper mt-2">
+        <div class="year-input">and year:</div>
+        <%= render_range_input(field_name, :end, input_label_range_end, maxlength) %>
+      </div>
+      <div class="range_input_wrapper mt-2 mb-2">
+        <%= submit_tag t('blacklight.range_limit.submit_limit'), class: BlacklightRangeLimit.classes[:submit] %>
+      </div>
+      <%# OVERRIDE end %>
+    <% end %>
+  <% end %>
+
+  <!-- no results profile if missing is selected -->
+  <% unless selected_missing_for_range_limit?(field_name) %>
+    <!-- you can hide this if you want, but it has to be on page if you want
+         JS slider and calculated facets to show up, JS sniffs it. -->
+    <div class="profile">
+        <% if stats_for_field?(field_name) %>
+          <!-- No stats information found for field  in search response -->
+        <% end %>
+
+        <% if (min = range_results_endpoint(field_name, :min)) &&
+              (max = range_results_endpoint(field_name, :max)) %>
+          <p class="range subsection <%= "slider_js" unless field_config[:slider_js] == false  %>">
+            Current results range from <span class="min"><%= range_results_endpoint(field_name, :min) %></span> to <span class="max"><%= range_results_endpoint(field_name, :max) %></span>
+          </p>
+
+          <% if field_config[:segments] != false %>
+            <div class="distribution subsection <%= 'chart_js' unless field_config[:chart_js] == false %>">
+              <!-- if  we already fetched segments from solr, display them
+                   here. Otherwise, display a link to fetch them, which JS
+                   will AJAX fetch.  -->
+              <% if solr_range_queries_to_a(field_name).length > 0 %>
+
+                 <%= render(:partial => "blacklight_range_limit/range_segments", :locals => {:solr_field => field_name}) %>
+
+              <% else %>
+                <%= link_to('View distribution', main_app.url_for(search_state.to_h.merge(action: 'range_limit', range_field: field_name, range_start: min, range_end: max)), :class => "load_distribution") %>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+
+
+
+        <% if (stats = stats_for_field(field_name)) && stats["missing"] > 0 %>
+          <ul class="missing list-unstyled facet-values subsection">
+            <li>
+              <span class="facet-label">
+                <%= link_to BlacklightRangeLimit.labels[:missing], add_range_missing(field_name) %>
+              </span>
+              <span class="facet-count">
+                <%= number_with_delimiter(stats["missing"]) %>
+              </span>
+            </li>
+          </ul>
+        <% end %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
# Story

This commit aligns the way that date range limits work with Palni/Palci's implementation.  The original problem was that the date parser wasn't particularly robust and would fail on dates that were not of a certain format.  Here we take the more conformed dates from the edtf_tesim field and strip the year out and sort it by that.  We now limit the number of characters to only 4 so that only YYYY can be searched.  The facet UI has been updated to make it more clear as well. We redefine the date_ssi field to hold only the year and that is what we search with.  This does not affect XML and CSV catalog result exports because date_tesim is used there.

Ref:
  - https://github.com/scientist-softserv/west-virginia-university/issues/112

# Screenshots / Video

<img width="917" alt="Screenshot 2023-10-27 at 16 16 34" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/fd39b3d3-ff7a-4305-a3a4-c85f9ff6ccf8">
<img width="1612" alt="Screenshot 2023-10-27 at 16 16 25" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/9fede3f5-fefd-4ffd-8016-b9d1b6cd8736">

