### PR TITLE
🐛 Add collection title to citation

### DIFF
--- a/hydra/app/services/chicago_citation_service.rb
+++ b/hydra/app/services/chicago_citation_service.rb
@@ -7,6 +7,7 @@ module ChicagoCitationService
       title = sanitize_value(document['title_tesim']&.first || document['description_tesim']&.first)
       date = sanitize_value(document['date_tesim']&.first)
       location = sanitize_value(document['physical_location_tesim']&.first)
+      collection_title = sanitize_value(document['collection_title_tesim']&.first)
       contributing_institution = sanitize_value(document['contributing_institution_tesim']&.first)
       url = original_url
       access_date = Date.today.strftime("%B %d, %Y")
@@ -14,9 +15,9 @@ module ChicagoCitationService
       text << "<i>#{title}</i>, " if title.present?
       text << "#{date}, " if date.present?
       text << "#{location}, " if location.present?
+      text << "#{collection_title}, " if collection_title.present?
       text << "#{contributing_institution}. " if contributing_institution.present?
-      text << "#{url}"
-      text << " (accessed #{access_date})."
+      text << "#{url} (accessed #{access_date})."
 
       text.strip.html_safe
     end

--- a/hydra/spec/services/chicago_citation_service_spec.rb
+++ b/hydra/spec/services/chicago_citation_service_spec.rb
@@ -14,13 +14,14 @@ RSpec.describe ChicagoCitationService do
           'title_tesim' => ['Title'],
           'date_tesim' => ['Date'],
           'physical_location_tesim' => ['Physical Location'],
+          'collection_title_tesim' => ['Collection Title'],
           'contributing_institution_tesim' => ['Contributing Institution']
         }
       end
 
       it 'returns a formatted citation' do
         expect(service.format(document: doc, original_url: url)).to eq(
-          "<i>Title</i>, Date, Physical Location, Contributing Institution. https://www.wvu.edu/catalog/1234 (accessed #{access_date})."
+          "<i>Title</i>, Date, Physical Location, Collection Title, Contributing Institution. https://www.wvu.edu/catalog/1234 (accessed #{access_date})."
         )
       end
     end


### PR DESCRIPTION
# Story

This commit will add the collection title, which is the dcterms:relation to the citation.

Ref:
  - https://github.com/scientist-softserv/west-virginia-university/issues/114

# Expected Behavior Before Changes
The collection title was not in the citation.

# Expected Behavior After Changes
Now the collection title will appear in the citation.

# Screenshots / Video

<img width="1562" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/8441310c-bd40-4e3a-946b-cb3e81d943e6">
