### PR TITLE
🐛 Fix unintialized constant error for Bulkrax

### DIFF
--- a/hydra/app/models/acda.rb
+++ b/hydra/app/models/acda.rb
@@ -7,7 +7,7 @@ class Acda < ActiveFedora::Base
   after_create :generate_thumbnail
   after_save :clear_empty_fields
 
-  self.indexer = Indexer
+  self.indexer = ::Indexer
 
   def generate_thumbnail
     # queue job to generate thumbnail


### PR DESCRIPTION
In the context of a Bulkrax import, we were seeing an unintialized constant error for `Acda::Indexer`.  This commit will correctly namespace it.
