### PR TITLE
🐛 Update #add_date to handle more cases

### DIFF
--- a/hydra/app/helpers/blacklight_helper.rb
+++ b/hydra/app/helpers/blacklight_helper.rb
@@ -4,4 +4,19 @@ module BlacklightHelper
   def application_name
     'American Congress Digital Archives Portal'
   end
+
+  def extract_year(date_string)
+    if date_string =~ /\A\d{4}-\d{2}-\d{2}\z/
+      # Matches YYYY-MM-DD
+      Date.strptime(date_string, '%Y-%m-%d').year
+    elsif date_string =~ /\A\d{4}-\d{2}\z/
+      # Matches YYYY-MM
+      Date.strptime(date_string, '%Y-%m').year
+    elsif date_string =~ /\A\d{4}\z/
+      # Matches YYYY
+      Date.new(date_string.to_i).year
+    else
+      date_string
+    end
+  end
 end

--- a/hydra/app/indexers/indexer.rb
+++ b/hydra/app/indexers/indexer.rb
@@ -8,11 +8,32 @@ class Indexer < ActiveFedora::IndexingService
   private
 
     def add_date(solr_doc)
-      # The allowed date formats are either YYYY, YYYY-MM, or YYYY-MM-DD
-      # the date must be formatted as a 4 digit year in order to be sorted.
-      valid_date_formats = /\A(\d{4})(?:-\d{2}(?:-\d{2})?)?\z/
       date_string = solr_doc['edtf_ssi']
-      year = date_string&.match(valid_date_formats)&.captures&.first
-      solr_doc['date_ssi'] = year if year
+
+      # If there is no date, set it to 'unknown', otherwise it would be blank and show up first in an ascending sort
+      return solr_doc['date_ssi'] = 'unknown' if date_string.blank?
+
+      # Check for 'YYYYs' or "YYYY's" format and convert it to just 'YYYY'
+      year_match = date_string&.match(/\b(\d{4})(?:'s|s)\b/)
+      return solr_doc['date_ssi'] = year_match[1] if year_match # Just the year
+
+      begin
+        # Use Date.parse for other cases
+        date = Date.parse(date_string)
+        # Determine the format needed based on the precision of the original date string
+        if date_string.match(/\b\d{4}-\d{2}-\d{2}\b/)
+          formatted_date = date.strftime('%Y-%m-%d') # YYYY-MM-DD
+        elsif date_string.match(/\b\d{4}-\d{2}\b/)
+          formatted_date = date.strftime('%Y-%m') # YYYY-MM
+        else
+          formatted_date = date.strftime('%Y') # YYYY
+        end
+        solr_doc['date_ssi'] = formatted_date
+      rescue ArgumentError
+        # If Date.parse fails to parse the date_string, it could be a simple year or an unsupported format.
+        # In such a case, fallback to regex to extract the year.
+        year_match = date_string&.match(/\b(\d{4})\b/)
+        solr_doc['date_ssi'] = year_match[1] if year_match
+      end
     end
 end

--- a/hydra/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/hydra/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -65,10 +65,10 @@
           <!-- No stats information found for field  in search response -->
         <% end %>
 
-        <% if (min = range_results_endpoint(field_name, :min)) &&
-              (max = range_results_endpoint(field_name, :max)) %>
+        <% if (min = extract_year(range_results_endpoint(field_name, :min))) &&
+              (max = extract_year(range_results_endpoint(field_name, :max))) %>
           <p class="range subsection <%= "slider_js" unless field_config[:slider_js] == false  %>">
-            Current results range from <span class="min"><%= range_results_endpoint(field_name, :min) %></span> to <span class="max"><%= range_results_endpoint(field_name, :max) %></span>
+            Current results range from <span class="min"><%= min %></span> to <span class="max"><%= max %></span>
           </p>
 
           <% if field_config[:segments] != false %>


### PR DESCRIPTION
# Story

This commit will update the #add_date method to handle cases such as:

YYYY
YYYYs
YYYY's
YYYY-MM
YYYY-MM-DD
No date provided (blank string)

Ref:
  - https://github.com/scientist-softserv/west-virginia-university/issues/112
---
This commit will make it so that only the year is shown in the date range facet which will make it match the input fields.

# Expected Behavior Before Changes
Dates like "approximately 1963" weren't handled correctly and throwing the sort and display off.

# Expected Behavior After Changes
More edge cases are being handled.

# Screenshots / Video
https://github.com/scientist-softserv/west-virginia-university/assets/19597776/bdbfc5fd-e667-4e7c-ae9f-da478a3678c4

---

<img width="481" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/3ff185e4-38cb-4245-8869-4ecac962f6d6">

