### PR TITLE
🐛 Fix bookmark export

### DIFF
--- a/hydra/app/helpers/blacklight_helper.rb
+++ b/hydra/app/helpers/blacklight_helper.rb
@@ -19,4 +19,14 @@ module BlacklightHelper
       date_string
     end
   end
+
+  def export_params
+    # Checks if we're exporting from the bookmarks page
+    bookmarks = controller.instance_variable_get(:@bookmarks)
+    return params unless bookmarks
+
+    identifiers = bookmarks.map { |bookmark| SolrDocument.find(bookmark.document_id)['identifier_ssi'] }
+    params.merge('search_field' => 'identifier',
+                 'q' => identifiers.map { |identifier| "\"#{identifier}\"" }.join(' OR '))
+  end
 end

--- a/hydra/app/views/catalog/_export_search_results.html.erb
+++ b/hydra/app/views/catalog/_export_search_results.html.erb
@@ -4,7 +4,13 @@
   </button>
 
   <ul class="dropdown-menu">
-    <li><%= link_to "Export to CSV", catalog_export_path(rows: @response.total, format: :csv, q: params[:q]) %></li>
-    <li><%= link_to "Export to XML", catalog_export_path(rows: @response.total, format: :xml, q: params[:q]) %></li>
+    <li><%= link_to "Export to CSV", catalog_export_path(rows: @response.total,
+                                                         format: :csv,
+                                                         search_field: export_params[:search_field],
+                                                         q: export_params[:q]) %></li>
+    <li><%= link_to "Export to XML", catalog_export_path(rows: @response.total,
+                                                         format: :xml,
+                                                         search_field: export_params[:search_field],
+                                                         q: export_params[:q]) %></li>
   </ul>
 </div>


### PR DESCRIPTION
# Story

This commit will address a bug in the bookmark export.  Previously, the export button on the bookmarks page would export with effectively no query params.  This is because the params did not have a `q` and basically did a `q=""` search.  If you had 1 bookmark then it'll just return the first result from an empty query search, which most likely would not be the bookmarked record you wanted.

This also enables the user to pick specific results via the bookmark feature and only export those results.

# Expected Behavior Before Changes
Bookmark exports were not working as intended and only returned an empty query search hit.

# Expected Behavior After Changes
Bookmark exports now are scoped to record identifiers and should return the expected hits.

# Screenshots / Video


https://github.com/scientist-softserv/west-virginia-university/assets/19597776/d4763b45-1bbf-4488-b606-89104b56e360
