### PR TITLE
🎁 Generate thumbnails on update

### DIFF
--- a/hydra/app/jobs/generate_thumbs_job.rb
+++ b/hydra/app/jobs/generate_thumbs_job.rb
@@ -7,15 +7,14 @@ class GenerateThumbsJob < ApplicationJob
 
     # Ignore if record type is sound or moving image
     return if ((record.dc_type == 'Sound') || (record.dc_type.include? 'Moving'))
+    return record.thumbnail_file = nil if record.preview.blank?
 
-    # if record.preview is a pdf and record.thumbnail_file is nil
-    if record.thumbnail_file.nil?
-      if record.preview.include? 'pdf'
-        GeneratePdfThumbsJob.perform_later(identifier)
-      # tesing thumbnail generation for images from remote files
-      else
-        GenerateImageThumbsJob.perform_later(identifier)
-      end
+    # if record.preview is a pdf
+    if record.preview.include? 'pdf'
+      GeneratePdfThumbsJob.perform_later(identifier)
+    # tesing thumbnail generation for images from remote files
+    else
+      GenerateImageThumbsJob.perform_later(identifier)
     end
   end
 

--- a/hydra/app/models/acda.rb
+++ b/hydra/app/models/acda.rb
@@ -6,6 +6,11 @@ class Acda < ActiveFedora::Base
 
   after_create :generate_thumbnail
   after_save :clear_empty_fields
+  after_save :generate_thumbnail, if: :saved_change_to_preview?
+
+  def saved_change_to_preview?
+    previous_changes['preview'].present?
+  end
 
   self.indexer = ::Indexer
 


### PR DESCRIPTION
# Story

This commit will allow the `GenerateThumbsJob` to be called on update if the `preview` field has been changed.  We also handle errors better in case we don't have a valid URL for thumbnails.  If we get a invalid URL then the existing thumbnail will be removed to better indicate that there was something wrong with the URL.

There is now a lot of duplication between the `GenerateImageThumbsJob` and the `GeneratePdfThumbsJob`.  Perhaps a refactor in the future would be in order.

Ref:
- https://github.com/scientist-softserv/west-virginia-university/issues/155
- https://github.com/scientist-softserv/west-virginia-university/pull/154 (also needed for the state of WVU's data)

# Expected Behavior Before Changes
Thumbnails on were being generated on create.

# Expected Behavior After Changes
Thumbnails now generate on create and also when the `edm:preview` field gets updated.

# Screenshots / Video

https://github.com/scientist-softserv/west-virginia-university/assets/19597776/1d4638b0-f096-4f56-8ce1-21236163e839
