### PR TITLE
🎁 Check for thumbnail file

### DIFF
--- a/hydra/app/models/acda.rb
+++ b/hydra/app/models/acda.rb
@@ -9,7 +9,7 @@ class Acda < ActiveFedora::Base
   after_save :generate_thumbnail, if: :saved_change_to_preview?
 
   def saved_change_to_preview?
-    previous_changes['preview'].present?
+    previous_changes['preview'].present? || thumbnail_file.blank?
   end
 
   self.indexer = ::Indexer


### PR DESCRIPTION
This commit will add the condition for checking if a thumbnail file exists on the record.  If the `thumbnail_file` returns `nil` then it should also execute `#generate_thumbnail`.

This change is needed particularly for WVU's current situation.  They have records with the `preview` field already set however the thumbnail isn't set.

Ref:
- https://github.com/scientist-softserv/west-virginia-university/issues/155