### PR TITLE
🐛 Fix footer blocking content

### DIFF
--- a/hydra/app/assets/stylesheets/blacklight.scss
+++ b/hydra/app/assets/stylesheets/blacklight.scss
@@ -11,6 +11,8 @@
     margin: 40px auto;
     padding-left: 0;
     padding-right: 0;
+    padding-bottom: 80px;
+    box-sizing: border-box;
     .row {
         margin-left: 0;
     	margin-right: 0;


### PR DESCRIPTION
This commit will adjust the main content container to be above the footer which is 80px.

## Before:
<img width="1104" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/d34ee165-d03e-4056-928e-04c693c94551">


## After:
<img width="1167" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/7bb14a7c-451a-4bda-92ba-44a7ebb55f38">
