### PR TITLE
🎁 Break image on show page when thumbnail is wrong

### DIFF
--- a/hydra/app/jobs/generate_image_thumbs_job.rb
+++ b/hydra/app/jobs/generate_image_thumbs_job.rb
@@ -32,8 +32,13 @@ class GenerateImageThumbsJob < ApplicationJob
     # check if the tempfile is indeed an image
     mime_type = `file --brief --mime-type #{Shellwords.escape(image_path)}`.strip
 
-    # sets thumbnail_file to nil if mime_type is not an image, so we don't retain the previous thumbnail
-    return record.thumbnail_file = nil unless mime_type.include?('image')
+    # sets thumbnail_file and image_file to nil if mime_type is not an image
+    # so we don't retain the previous thumbnail and image
+    unless mime_type.include?('image')
+      record.thumbnail_file = nil
+      record.image_file = nil
+      return
+    end
 
     record.files.build unless record.files.present?
 

--- a/hydra/app/jobs/generate_thumbs_job.rb
+++ b/hydra/app/jobs/generate_thumbs_job.rb
@@ -8,7 +8,12 @@ class GenerateThumbsJob < ApplicationJob
     # Ignore if record type is sound or moving image
     return if record.dc_type.nil?
     return if ((record.dc_type == 'Sound') || (record.dc_type.include? 'Moving'))
-    return record.thumbnail_file = nil if record.preview.blank?
+
+    if record.preview.blank?
+      record.thumbnail_file = nil
+      record.image_file = nil
+      return
+    end
 
     # if record.preview is a pdf
     if record.preview.include? 'pdf'


### PR DESCRIPTION
If the thumbnail is wrong, the thumbnail as well as the image on the show page should be broken.

Ref:
  - https://github.com/scientist-softserv/west-virginia-university/issues/155
