### PR TITLE
🐛 Fix bookmark toggle on show page

### DIFF
--- a/hydra/app/assets/javascripts/application.js
+++ b/hydra/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 // Required by Blacklight
 // -----------------------------------------------------
 //= require blacklight/blacklight
+//= require bookmark_toggle
 
 // Required by Bulkrax
 // -----------------------------------------------------

--- a/hydra/app/assets/javascripts/bookmark_toggle.js
+++ b/hydra/app/assets/javascripts/bookmark_toggle.js
@@ -1,0 +1,50 @@
+//= require blacklight/core
+//= require blacklight/checkbox_submit
+
+// Set up a MutationObserver to observe when the bookmark form is added to the DOM.
+// The original javascript wasn't working on the record's show page because the form
+// element was not loaded when the event listener was being added.  It works fine on
+// the index page, however.
+
+(function ($) {
+  function toggleBookmarkBehavior() {
+    //change form submit toggle to checkbox
+    $(Blacklight.do_bookmark_toggle_behavior.selector).bl_checkbox_submit({
+      //css_class is added to elements added, plus used for id base
+      css_class: "toggle_bookmark",
+      success: function (checked, response) {
+        if (response.bookmarks) {
+          $("[data-role=bookmark-counter]").text(response.bookmarks.count);
+        }
+      },
+    });
+  }
+  Blacklight.do_bookmark_toggle_behavior.selector = "form.bookmark_toggle";
+
+  var observer = new MutationObserver(function (mutations, obs) {
+    mutations.forEach(function (mutation) {
+      if (mutation.addedNodes) {
+        for (var i = 0; i < mutation.addedNodes.length; i++) {
+          // Check if the added node is the form or contains the form
+          var addedNode = mutation.addedNodes[i];
+          if (
+            addedNode.nodeType === 1 &&
+            (addedNode.matches(
+              Blacklight.do_bookmark_toggle_behavior.selector
+            ) ||
+              addedNode.querySelector("form.bookmark_toggle"))
+          ) {
+            toggleBookmarkBehavior();
+            obs.disconnect();
+          }
+        }
+      }
+    });
+  });
+
+  // Start observing
+  observer.observe(document.body, {
+    childList: true, // observe direct children
+    subtree: true, // and lower descendants too
+  });
+})(jQuery);


### PR DESCRIPTION
# Story

This commit will resolve the asynchronous loading issue of the bookmark toggle form on the show page by using a MutationObserver. This ensures the `bl_checkbox_submit` function is initialized after the form is dynamically added to the DOM. The observer is disconnected after successful initialization for performance optimization.

# Screenshots / Video
![wvu-bookmark](https://github.com/scientist-softserv/west-virginia-university/assets/19597776/eeea1534-1b8d-4161-b59a-e8cb07c0dbb6)
