### PR TITLE
🐛 Up footer's `z-index`

### DIFF
--- a/hydra/app/assets/stylesheets/partials/_partners.scss
+++ b/hydra/app/assets/stylesheets/partials/_partners.scss
@@ -4,6 +4,7 @@
     position: fixed;
     bottom: 0;
     background-color: #f7f7f7;
+    z-index: 4;
 }
 .partners ul {
     display: inline-block;
@@ -34,6 +35,6 @@
         padding: 10px;
     }
     .partners li {
-        margin: 10px 
+        margin: 10px
     }
 }


### PR DESCRIPTION
# Story

This commit is another quality of life improvement for the footer.  It pumps the `z-index` above the pagination current page indicator so the indicator doesn't overlap the footer.

## Before
<img width="312" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/481ae96b-219c-4b2f-92b5-c655517fe870">


## After
<img width="349" alt="image" src="https://github.com/scientist-softserv/west-virginia-university/assets/19597776/fdbf3e98-b2f6-46a6-a0da-75941597e6e7">
