### PR TITLE
🐛 Fix clearing of tmp images

### DIFF
--- a/hydra/app/jobs/generate_image_thumbs_job.rb
+++ b/hydra/app/jobs/generate_image_thumbs_job.rb
@@ -60,7 +60,7 @@ class GenerateImageThumbsJob < ApplicationJob
     File.delete(image_path) if File.exist?(image_path)
 
     # delete thumbnails with identifer
-    Dir.glob("#{image_path}/#{id}*").each do |file|
+    Dir.glob("#{File.dirname(image_path)}/#{id}*").each do |file|
       File.delete(file)
     end
 

--- a/hydra/app/jobs/generate_pdf_thumbs_job.rb
+++ b/hydra/app/jobs/generate_pdf_thumbs_job.rb
@@ -77,7 +77,7 @@ class GeneratePdfThumbsJob < ApplicationJob
     File.delete(pdf_path) if File.exist?(pdf_path)
 
     # delete all images with id
-    Dir.glob("#{image_path}/#{id}*").each do |file|
+    Dir.glob("#{File.dirname(image_path)}/#{id}*").each do |file|
       File.delete(file)
     end
 


### PR DESCRIPTION
# Story

This commit will get the path to the tmp images directory correctly and will allow the clean up to execute correctly.