### PR TITLE
Fix accordion behavior

### DIFF
--- a/hydra/app/assets/javascripts/application.js
+++ b/hydra/app/assets/javascripts/application.js
@@ -34,8 +34,8 @@
 
 // Required by Bulkrax
 // -----------------------------------------------------
-//= require bulkrax/application
 //= require datatables
+//= require bulkrax/application
 
 // CUSTOM COLLECTION JS
 // -----------------------------------------------------
@@ -44,6 +44,7 @@
 //= require partials/toggles
 //= require partials/smooth_scroll
 //= require partials/cookie_modal
+//= require partials/nav_toggles
 
 
 // For blacklight_range_limit built-in JS, if you don't want it you don't need

--- a/hydra/app/assets/javascripts/partials/nav_toggles.js
+++ b/hydra/app/assets/javascripts/partials/nav_toggles.js
@@ -1,0 +1,36 @@
+  // enables the tabs in the importers/exporters pages.
+  $(document).ready(function() {
+    $('.bulkrax-nav-tab-top-margin.nav-tabs a').click(function(e) {
+      e.preventDefault();
+
+      // Remove active class from all tabs and hide all tab content
+      $('.bulkrax-nav-tab-top-margin.nav-tabs a').parent().removeClass('active');
+      $('.tab-content .tab-pane').removeClass('active');
+
+      // Add active class to clicked tab and show its content
+      $(this).parent().addClass('active');
+      $($(this).attr('href')).addClass('active');
+    });
+
+    // toggles tabs on the errors page
+    $('#full-errors-tab, #full-errors-tab a').click(function(e) {
+      $('#raw-errors-tab, #bulkrax-raw-toggle-1').removeClass('active');
+      $('#full-errors-tab, #bulkrax-full-toggle-1').addClass('active');
+    })
+
+    $('#raw-errors-tab, #raw-errors-tab a').click(function(e) {
+      $('#full-errors-tab, #bulkrax-full-toggle-1').removeClass('active');
+      $('#raw-errors-tab, #bulkrax-raw-toggle-1').addClass('active');
+    })
+
+    // toggles tabs on the parser mappings page
+    $('#full-mappings-tab, #full-mappings-tab a').click(function(e) {
+      $('#raw-mappings-tab, #bulkrax-raw-toggle-2').removeClass('active');
+      $('#full-mappings-tab, #bulkrax-full-toggle-2').addClass('active');
+    })
+
+    $('#raw-mappings-tab, #raw-mappings-tab a').click(function(e) {
+      $('#full-mappings-tab, #bulkrax-full-toggle-2').removeClass('active');
+      $('#raw-mappings-tab, #bulkrax-raw-toggle-2').addClass('active');
+    })
+  });

--- a/hydra/app/assets/stylesheets/application.scss
+++ b/hydra/app/assets/stylesheets/application.scss
@@ -25,7 +25,6 @@
 // it is important that the order gets imported in a certain way so that variables are able to be used in other scss files
 @import "partials/variables";
 @import "blacklight";
-@import "bulkrax/application";
 @import "partials/wvu";
 @import "partials/wvrhc";
 @import "partials/helpmodal";
@@ -35,7 +34,8 @@
 @import "partials/alerts";
 @import "partials/partners";
 @import "partials/carousel";
-@import "partials/bulkrax";
 @import "date_facet_range";
 @import "blacklight_advanced_search";
 @import "datatables";
+@import "bulkrax/application";
+@import "partials/bulkrax";

--- a/hydra/app/assets/stylesheets/partials/_bulkrax.scss
+++ b/hydra/app/assets/stylesheets/partials/_bulkrax.scss
@@ -24,3 +24,22 @@
     }
   }
 }
+
+/* Bulkrax Forms */
+.importer-form, .exporter-form, .bulkrax-align-text, .accordion-item {
+  .form-control {
+    color: rgb(51, 51, 51)
+  }
+  .nav-tabs > li.active > a {
+    color: #337ab7
+  }
+  .accordion-body, .accordion-header {
+    text-align: left;
+  }
+  .accordion-body {
+    strong {
+      width: 40%;
+      display: inline-block;
+    }
+  }
+}

--- a/hydra/app/assets/stylesheets/partials/_custom.scss
+++ b/hydra/app/assets/stylesheets/partials/_custom.scss
@@ -384,26 +384,6 @@ html, form, nav, div {
 	}
 }
 
-
-/* Bulkrax Forms */
-.importer-form, .exporter-form, .bulkrax-align-text, .accordion-container {
-  .form-control {
-    color: rgb(51, 51, 51)
-  }
-  .nav-tabs > li.active > a {
-    color: #337ab7
-  }
-  .accordion-body, .accordion-heading {
-    text-align: left;
-  }
-  .accordion-body {
-    strong {
-      width: 40%;
-      display: inline-block;
-    }
-  }
-}
-
 /*********************************************************************
 	768px to 1024px
 **********************************************************************/

--- a/hydra/app/views/bulkrax/entries/_parsed_metadata.html.erb
+++ b/hydra/app/views/bulkrax/entries/_parsed_metadata.html.erb
@@ -1,0 +1,19 @@
+<%# OVERRIDE BULKRAX 8 to change accordion to bootstrap 5 %>
+<% if @entry.parsed_metadata.present? %>
+  <div class="accordion accordion-flush" id="parsed-metadata-heading">
+    <div class="accordion-item">
+      <h2 class="accordion-header">
+        <a class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#parsed-metadata-show" aria-expanded="false" aria-controls="parsed-metadata-show">
+          Parsed Metadata:
+        </a>
+      </h2>
+      <div id="parsed-metadata-show" class="accordion-collapse collapse"  role="tabpanel" data-bs-parent="#parsed-metadata-heading">
+        <div class="accordion-body">
+          <% @entry.parsed_metadata.each do |k, v| %>
+            <strong><%= k %>:</strong> <%= v %><br>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/hydra/app/views/bulkrax/entries/_raw_metadata.html.erb
+++ b/hydra/app/views/bulkrax/entries/_raw_metadata.html.erb
@@ -1,0 +1,19 @@
+<%# OVERRIDE BULKRAX 8 to change accordion to bootstrap 5 %>
+<% if @entry.raw_metadata.present? %>
+  <div class="accordion accordion-flush" id="raw-metadata-heading">
+    <div class="accordion-item">
+      <h2 class="accordion-header">
+        <a class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#raw-metadata-show" aria-expanded="false" aria-controls="raw-metadata-show">
+          Raw Metadata:
+        </a>
+      </h2>
+      <div id="raw-metadata-show" class="accordion-collapse collapse"  role="tabpanel" aria-labelledby="raw-metadata-show">
+        <div class="accordion-body">
+        <% @entry.raw_metadata.each do |k, v| %>
+          <strong><%= k %>:</strong> <%= v %><br>
+        <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/hydra/app/views/bulkrax/importers/show.html.erb
+++ b/hydra/app/views/bulkrax/importers/show.html.erb
@@ -1,0 +1,84 @@
+<%# OVERRIDE BULKRAX 8 to pull accordion out of show and change to bootstrap 5 %>
+<div class="col-xs-12 main-header">
+  <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importer: <%= @importer.name %></h1>
+  <div class="pull-right">
+    <%= link_to 'Download Original File', importer_original_file_path(@importer.id), class: 'btn btn-primary', data: { turbolinks: false } if @importer.original_file %>
+    <% if @importer.failed_entries? %>
+      <%= link_to 'Export Errored Entries', importer_export_errors_path(@importer.id), class: 'btn btn-primary', data: { turbolinks: false }%>
+      <%= link_to 'Upload Corrected Entries', importer_upload_corrected_entries_path(@importer.id), class: 'btn btn-primary' if @importer.parser.is_a?(Bulkrax::CsvParser) %>
+    <% end %>
+  </div>
+</div>
+<div class="panel panel-default bulkrax-align-text">
+  <div class="panel-body">
+    <p class="bulkrax-p-align">
+      <strong><%= t('bulkrax.importer.labels.name') %>:</strong>
+      <%= @importer.name %>
+    </p>
+    <% if defined?(::Hyrax) %>
+      <p class="bulkrax-p-align">
+        <strong><%= t('bulkrax.importer.labels.admin_set') %>:</strong>
+        <%= @importer.admin_set_id %>
+      </p>
+    <% end %>
+    <p class="bulkrax-p-align">
+      <strong><%= t('bulkrax.importer.labels.user') %>:</strong>
+      <%= @importer.user %>
+    </p>
+    <p class="bulkrax-p-align">
+      <strong><%= t('bulkrax.importer.labels.frequency') %>:</strong>
+      <%= @importer.frequency %>
+    </p>
+    <p class="bulkrax-p-align">
+      <strong><%= t('bulkrax.importer.labels.parser_klass') %>:</strong>
+      <%= @importer.parser_klass %>
+    </p>
+    <p class="bulkrax-p-align">
+      <strong><%= t('bulkrax.importer.labels.limit') %>:</strong>
+      <%= @importer.limit %>
+    </p>
+
+    <%# OVERRIDE: change accordion to bootstrap 5 %>
+    <%= render partial: 'bulkrax/shared/bulkrax_errors', locals: {item: @importer} %>
+    <%= render partial: 'bulkrax/shared/parser_fields', locals: {item: @importer} %>
+    <%= render partial: 'bulkrax/shared/bulkrax_field_mapping', locals: {item: @importer} %>
+
+    <p class="bulkrax-p-align" title="<%= @importer.last_run&.processed_works %> processed, <%= @importer.last_run&.failed_works %> failed">
+      <strong><%= t('bulkrax.importer.labels.total_work_entries') %>:</strong>
+      <%= @importer.last_run&.total_work_entries %>
+    </p>
+
+    <p class="bulkrax-p-align" title="<%= @importer.last_run&.processed_collections %> processed, <%= @importer.last_run&.failed_collections %> failed">
+      <strong><%= t('bulkrax.importer.labels.total_collections') %>:</strong>
+      <%= @importer.last_run&.total_collection_entries %>
+    </p>
+
+    <p class="bulkrax-p-align" title="<%= @importer.last_run&.processed_file_sets %> processed, <%= @importer.last_run&.failed_file_sets %> failed">
+      <strong><%= t('bulkrax.importer.labels.total_file_sets') %>:</strong>
+      <%= @importer.last_run&.total_file_set_entries %>
+    </p>
+
+    <div class="bulkrax-nav-tab-bottom-margin">
+      <!-- Nav tabs -->
+      <div class="outline">
+        <%= render partial: 'bulkrax/shared/entries_tab', locals: { item: @importer} %>
+      </div>
+      <%= render partial: 'bulkrax/importers/edit_item_buttons', locals: { item: @importer, e: @first_entry } if @first_entry.present? %>
+    </div>
+
+    <p class="bulkrax-p-align">
+      <%= link_to 'Edit', edit_importer_path(@importer) %>
+      |
+      <%= link_to 'Back', importers_path %><br /><br />
+    </p>
+
+    <% if @importer.validate_only == true %>
+      <div class='pull-left'>
+        <%= button_to 'Continue', importer_continue_path(@importer), method: :put, class: 'btn btn-primary' %>
+      </div>
+      <div class='pull-right'>
+        <%= button_to 'Discard', @importer, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/hydra/app/views/bulkrax/shared/_bulkrax_errors.html.erb
+++ b/hydra/app/views/bulkrax/shared/_bulkrax_errors.html.erb
@@ -1,0 +1,55 @@
+<%# OVERRIDE BULKRAX 8 to change accordion to bootstrap 5 %>
+<% if item.failed? %>
+  <div class="accordion accordion-flush" id="error-trace-heading">
+    <div class="accordion-item">
+      <h2 class="accordion-header">
+        <a class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#error-trace-show" aria-expanded="false" aria-controls="error-trace-show">
+          Errors:
+        </a>
+      </h2>
+      <div id="error-trace-show" class="accordion-collapse collapse"  role="tabpanel" data-bs-parent="#error-trace-heading">
+        <div class="accordion-body">
+          <div class="bulkrax-nav-tab-bottom-margin">
+
+            <!-- Toggle buttons -->
+            <div class="btn-group pull-right" role="group" aria-label="...">
+              <button id="full-errors-tab" type="button" class="btn btn-light active"><a href="#bulkrax-full-toggle-1" aria-controls="bulkrax-full-toggle-1" role="tab" data-toggle="tab">Full</a></button>
+              <button id="raw-errors-tab" type="button" class="btn btn-light"><a href="#bulkrax-raw-toggle-1" aria-controls="bulkrax-raw-toggle-1" role="tab" data-toggle="tab">Raw</a></button>
+            </div>
+            <!-- Tab panes -->
+            <div class="tab-content">
+              <div role="tabpanel" class="tab-pane active" id="bulkrax-full-toggle-1">
+                <strong>Errored at:</strong> <%= item.status_at %><br /><br />
+                <strong>Error:</strong> <%= item.current_status.error_class %> - <%= item.current_status.error_message %><br /><br />
+                <strong>Error Trace:</strong><br/><br />
+                <% item.current_status.error_backtrace.each do |v| %>
+                  <%= coderay(v, { wrap: :page, css: :class, tab_width: 200, break_lines: true }) %>
+                  <br>
+                <% end %>
+              </div>
+              <div role="tabpanel" class="tab-pane" id="bulkrax-raw-toggle-1">
+                <strong>Errored at:</strong> <%= item.status_at %><br /><br />
+                <strong>Error:</strong> <%= item.current_status.error_class %> - <%= item.current_status.error_message %><br /><br />
+                <strong>Error Trace:</strong><br/><br />
+                <% item.current_status.error_backtrace.each do |v| %>
+                  <%= coderay(v, { css: :class, tab_width: 0, break_lines: false }) %>
+                  <br>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+<% elsif item.succeeded? %>
+  <p class='bulkrax-p-align'>
+    <strong>Succeeded At:</strong> <%= item.status_at %>
+  </p>
+<% else %>
+  <p class='bulkrax-p-align'>
+    <strong>Succeeded At:</strong> Item has not yet been <%= @importer.present? ? 'imported' : 'exported' %> successfully
+  </p>
+<% end %>

--- a/hydra/app/views/bulkrax/shared/_bulkrax_field_mapping.html.erb
+++ b/hydra/app/views/bulkrax/shared/_bulkrax_field_mapping.html.erb
@@ -1,0 +1,41 @@
+<%# OVERRIDE BULKRAX 8 to change accordion to bootstrap 5 %>
+<% if item.field_mapping.present? %>
+  <div class="accordion accordion-flush" id="field-mapping-show-heading">
+    <div class="accordion-item">
+      <h2 class="accordion-header">
+        <a class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#field-mapping-show" aria-expanded="false" aria-controls="field-mapping-show">
+          Field mapping:
+        </a>
+      </h2>
+      <div id="field-mapping-show" class="accordion-collapse collapse"  role="tabpanel" data-bs-parent="#field-mapping-show-heading">
+        <div class="accordion-body">
+          <div class="bulkrax-nav-tab-bottom-margin">
+
+            <!-- Toggle buttons -->
+            <div class="btn-group pull-right" role="group" aria-label="...">
+              <button id="full-mappings-tab" type="button" class="btn btn-light active"><a href="#bulkrax-full-toggle-2" aria-controls="bulkrax-full-toggle-2" role="tab" data-toggle="tab">Full</a></button>
+              <button id="raw-mappings-tab" type="button" class="btn btn-light"><a href="#bulkrax-raw-toggle-2" aria-controls="bulkrax-raw-toggle-2" role="tab" data-toggle="tab">Raw</a></button>
+            </div>
+            <!-- Tab panes -->
+            <div class="tab-content">
+              <div role="tabpanel" class="tab-pane active" id="bulkrax-full-toggle-2">
+                <% item.field_mapping.each do |k, v| %>
+                  <strong><%= k %>:</strong>
+                  <%= coderay(v, { wrap: :page, css: :class, tab_width: 200, break_lines: true }) %>
+                  <br />
+                <% end %>
+              </div>
+              <div role="tabpanel" class="tab-pane" id="bulkrax-raw-toggle-2">
+                <% item.field_mapping.each do |k, v| %>
+                  <%= coderay(v, { css: :class, tab_width: 0, break_lines: false }) %>
+                  <br />
+                <% end %>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/hydra/app/views/bulkrax/shared/_parser_fields.html.erb
+++ b/hydra/app/views/bulkrax/shared/_parser_fields.html.erb
@@ -1,0 +1,17 @@
+<%# OVERRIDE BULKRAX 8 to pull accordion out of show and change to bootstrap 5 %>
+<div class="accordion accordion-flush" id="parser-fields-heading">
+  <div class="accordion-item">
+    <h2 class="accordion-header">
+      <a class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#parser-fields-show" aria-expanded="false" aria-controls="parser-fields-show">
+        Parser fields:
+      </a>
+    </h2>
+    <div id="parser-fields-show" class="accordion-collapse collapse"  role="tabpanel" data-bs-parent="#parser-fields-heading">
+      <div class="accordion-body">
+        <% item.parser_fields.each do |key,value| %>
+          <strong><%= key %>:</strong> <%= value %> <br />
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/hydra/app/views/layouts/collection.html.erb
+++ b/hydra/app/views/layouts/collection.html.erb
@@ -67,10 +67,6 @@
     <%= render "shared/google_analytics" %>
 
     <!-- JavaScripts -->
-    <%# Needed to add these two to make accordions and datatables work in Bulkrax %>
-    <%# It seems they need to go before the application.js %>
-    <%= javascript_include_tag "https://code.jquery.com/jquery-3.7.1.slim.min.js", crossorigin: "anonymous" %>
-    <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js", crossorigin: "anonymous" %>
     <%= javascript_include_tag "application" %>
 
     <!-- Share This Integration -->


### PR DESCRIPTION
# Story

Bulkrax basically uses older bootstrap syntax.
In order to fix accordion and button tab behaviors, the partials were pulled in and updated to bootstrap 5.

Temporary code was removed from collection.html.erb now that the accordion behavior is correct.

Once this behavior is backported into Bulkrax, these overrides can be removed.

# Screenshots

<details>
<summary>Entries Show Page</summary>

![Screenshot 2024-12-11 at 7 20 45 PM](https://github.com/user-attachments/assets/b76192e1-4ea2-411c-b9e5-471394770731)

![Screenshot 2024-12-11 at 7 20 50 PM](https://github.com/user-attachments/assets/dd31b539-8deb-41b8-a174-d38e387cea32)

</details>
