### PR TITLE
Background validation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -124,6 +124,10 @@ To get data into the app:
 - You will have to log into the popup.  The username is in `ENV['BULKRAX_USERNAME']` and the password is in `ENV['BULKRAX_PW']`.  For local development, see [./env/env.dev.hydra](./env/env.dev.hydra).
   - Barring that, shell into the web container (e.g. `docker compose -f docker-compose.dev.yml exec web bash`) and run `echo "$BULKRAX_USERNAME:$BULKRAX_PW"`.
 
+### Emails
+
+Emails sent in development mode can be viewed at `http://localhost:3000/letter_opener/`
+
 ### Specs
 
 To run specs, bash into your `web` or `workers` container and run `rspec`.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,7 @@ services:
       - ./data/imports:/home/hydra/tmp/imports
       - ./data/exports:/home/hydra/tmp/exports
       - ./data/validations:/home/hydra/tmp/validations
+      - ./data/letter_opener:/home/hydra/tmp/letter_opener
       # don't mount tmp directory
       - /home/hydra/tmp
     networks:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,9 +9,9 @@ services:
     volumes:
       - ./hydra:/home/hydra
       # map in various bash scripts
-      - ./scripts:/home/hydra/scripts  
+      - ./scripts:/home/hydra/scripts
       # map in various persistent directories in the data folder
-      - ./data/logs:/home/hydra/log 
+      - ./data/logs:/home/hydra/log
       - ./data/pdf:/home/hydra/tmp/pdf
       - ./data/thumbnails:/home/hydra/tmp/thumbnails
       - ./data/images:/home/hydra/tmp/images
@@ -20,8 +20,9 @@ services:
       # map in various persistent directories in the tmp folder
       - ./data/imports:/home/hydra/tmp/imports
       - ./data/exports:/home/hydra/tmp/exports
-      # don't mount tmp directory  
-      - /home/hydra/tmp 
+      - ./data/validations:/home/hydra/tmp/validations
+      # don't mount tmp directory
+      - /home/hydra/tmp
     networks:
       - hydra
 
@@ -46,7 +47,7 @@ services:
   workers:
     extends: app
     container_name: sidekiq
-    command:  bash -c "bundle install; bundle exec sidekiq -C config/sidekiq.yml"        
+    command:  bash -c "bundle install; bundle exec sidekiq -C config/sidekiq.yml"
     depends_on:
       redis:
         condition: service_started
@@ -93,17 +94,17 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - './env/env.fedora' 
+      - './env/env.fedora'
     volumes:
-      - fcrepo:/usr/local/tomcat/fcrepo-home                 
+      - fcrepo:/usr/local/tomcat/fcrepo-home
     logging:
       options:
-        max-size: 50m  
+        max-size: 50m
     healthcheck:
       test: "curl -f http://localhost:8080/fcrepo"
       interval: 5s
       timeout: 5s
-      retries: 20      
+      retries: 20
     depends_on:
       - db
     networks:
@@ -114,31 +115,31 @@ services:
     image: solr:9.5.0
     restart: on-failure
     env_file:
-      - './env/env.solr'       
+      - './env/env.solr'
     ports:
       - "8983:8983"
     user: root # run as root to change the permissions of the solr folder
     # Change permissions of the solr folder, create a default core and start solr as solr user
-    command: bash -c "sh /scripts/startup.sh hydra_dev" 
-    volumes:    
+    command: bash -c "sh /scripts/startup.sh hydra_dev"
+    volumes:
       - solr:/var/solr/data/hydra_dev/data
-      - ./data/logs/dev/:/var/solr/logs    
+      - ./data/logs/dev/:/var/solr/logs
       - ./solr9-setup:/solr9-setup
-      - ./scripts/startup-solr.sh:/scripts/startup.sh  
+      - ./scripts/startup-solr.sh:/scripts/startup.sh
     healthcheck:
       test: "curl -f localhost:8983/solr/#/"
       interval: 5s
       timeout: 5s
-      retries: 20        
+      retries: 20
     networks:
-      - hydra  
+      - hydra
 
   db:
     container_name: db
     image: postgres:16-alpine
     expose:
       - "5432"
-    env_file: 
+    env_file:
       - './env/env.db'
     volumes:
       - postgres:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,17 +12,18 @@ services:
       # map node_modules to a persistent volume
       - ./data/node_modules:/home/hydra/node_modules
       # map in various bash scripts
-      - ./scripts:/home/hydra/scripts  
+      - ./scripts:/home/hydra/scripts
       # map in various persistent directories in the data folder
-      - ./data/logs:/home/hydra/log 
+      - ./data/logs:/home/hydra/log
       - ./data/pdf:/home/hydra/tmp/pdf
       - ./data/thumbnails:/home/hydra/tmp/thumbnails
       - ./data/images:/home/hydra/tmp/images
       # map in various persistent directories in the tmp folder
       - ./data/imports:/home/hydra/tmp/imports
       - ./data/exports:/home/hydra/tmp/exports
-      # don't mount tmp directory  
-      - /home/hydra/tmp 
+      - ./data/validations:/home/hydra/tmp/validations
+      # don't mount tmp directory
+      - /home/hydra/tmp
     networks:
       - hydra
 
@@ -86,17 +87,17 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - './env/env.fedora' 
+      - './env/env.fedora'
     volumes:
-      - ./data/fcrepo:/usr/local/tomcat/fcrepo-home                 
+      - ./data/fcrepo:/usr/local/tomcat/fcrepo-home
     logging:
       options:
-        max-size: 50m  
+        max-size: 50m
     healthcheck:
       test: "curl -f http://localhost:8080/fcrepo"
       interval: 5s
       timeout: 5s
-      retries: 20      
+      retries: 20
     depends_on:
       - db
     networks:
@@ -107,28 +108,28 @@ services:
     image: solr:9.5.0
     restart: on-failure
     env_file:
-      - './env/env.solr'       
+      - './env/env.solr'
     ports:
       - "8983:8983"
     user: root # run as root to change the permissions of the solr folder
     # Change permissions of the solr folder, create a default core and start solr as solr user
-    command: bash -c "sh /scripts/startup.sh hydra_prod" 
-    volumes:    
+    command: bash -c "sh /scripts/startup.sh hydra_prod"
+    volumes:
       - ./data/solr:/var/solr/data/hydra_prod/data
-      - ./data/logs/dev/:/var/solr/logs    
+      - ./data/logs/dev/:/var/solr/logs
       - ./solr9-setup:/solr9-setup
-      - ./scripts/startup-solr.sh:/scripts/startup.sh  
+      - ./scripts/startup-solr.sh:/scripts/startup.sh
     healthcheck:
       test: "curl -f localhost:8983/solr/#/"
       interval: 5s
       timeout: 5s
-      retries: 20        
+      retries: 20
     networks:
-      - hydra  
+      - hydra
 
   db:
     container_name: db
-    image: postgres:16-alpine	
+    image: postgres:16-alpine
     ports:
       - "5432"
     env_file:

--- a/hydra/Gemfile
+++ b/hydra/Gemfile
@@ -116,6 +116,7 @@ group :test do
 end
 
 group :development do
+  gem 'letter_opener_web'
   gem 'web-console', '>= 3.3.0'
   gem 'spring', '< 4.0.0'
 end

--- a/hydra/Gemfile.lock
+++ b/hydra/Gemfile.lock
@@ -302,6 +302,9 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_list (1.2.1)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
     ld-patch (3.3.0)
       ebnf (~> 2.4)
       rdf (~> 3.3)
@@ -324,6 +327,13 @@ GEM
       parslet
       rdf (~> 3.0)
       rdf-vocab (~> 3.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     libxml-ruby (5.0.3)
     link_header (0.0.8)
     linkeddata (3.3.1)
@@ -735,6 +745,7 @@ DEPENDENCIES
   jettywrapper
   jquery-datatables
   jquery-rails
+  letter_opener_web
   listen
   mini_magick
   mutex_m

--- a/hydra/app/assets/javascripts/application.js
+++ b/hydra/app/assets/javascripts/application.js
@@ -45,6 +45,7 @@
 //= require partials/smooth_scroll
 //= require partials/cookie_modal
 //= require partials/nav_toggles
+//= require partials/toggle_required
 
 
 // For blacklight_range_limit built-in JS, if you don't want it you don't need

--- a/hydra/app/assets/javascripts/partials/toggle_required.js
+++ b/hydra/app/assets/javascripts/partials/toggle_required.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const email_field = document.getElementById('mail_to');
+  const checkbox = document.getElementById('checkbox');
+  checkbox.addEventListener('change', function() {
+    email_field.required = this.checked
+  });
+});

--- a/hydra/app/controllers/validations_controller.rb
+++ b/hydra/app/controllers/validations_controller.rb
@@ -11,7 +11,14 @@ class ValidationsController < ApplicationController
       return redirect_to validate_path
     end
 
-    @results = validate_file
+    @path = params[:csv_file].tempfile.path
+    if params[:background_job] == '1'
+      submit_validate_job
+      flash[:notice] = 'Validation Job has been submitted. Results will be sent to provided email address.'
+      redirect_to validate_path
+    else
+      @results = validate_file
+    end
   rescue CSV::MalformedCSVError
     flash[:error] = 'Invalid CSV file format'
     redirect_to validate_path
@@ -19,30 +26,11 @@ class ValidationsController < ApplicationController
 
   private
 
+  def submit_validate_job
+    ValidateJob.perform_later(path: @path, mail_to: params[:mail_to])
+  end
+
   def validate_file
-    csv_path = params['csv_file'].tempfile
-    csv_data = File.read(csv_path)
-    results = []
-
-    headers = CSV.parse(csv_data, headers: true).headers
-    invalid_headers = headers - bulkrax_headers
-    results << invalid_headers.map { |header| { row: 1, header: header, message: "<strong>#{header}</strong> is an invalid header" } } if invalid_headers.present?
-
-    CSV.parse(csv_data, headers: true).each_with_index do |row, index|
-      row_results = validate_row(row: row, row_number: index + 2)
-      results << row_results if row_results.present?
-    end
-
-    results.flatten
-  end
-
-  def validate_row(row:, row_number:)
-    validator = ValidationService.new(row, row_number)
-    validator.validate
-  end
-
-  def bulkrax_headers
-    # taking out the 'bulkrax_identifier' field because WVU csv's don't use it
-    Bulkrax.field_mappings["Bulkrax::CsvParser"].values.flat_map { |hash| hash[:from] } - ['bulkrax_identifier']
+    ValidationService.new(path: @path).validate
   end
 end

--- a/hydra/app/controllers/validations_controller.rb
+++ b/hydra/app/controllers/validations_controller.rb
@@ -27,7 +27,7 @@ class ValidationsController < ApplicationController
   private
 
   def submit_validate_job
-    ValidateJob.perform_later(path: @path, mail_to: params[:mail_to])
+    ValidateJob.perform_later(path: @path, file_name: params['csv_file'].original_filename, mail_to: params[:mail_to])
   end
 
   def validate_file

--- a/hydra/app/jobs/validate_job.rb
+++ b/hydra/app/jobs/validate_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ValidateJob < ApplicationJob
+  queue_as :default
+
+  def perform(path:, mail_to:)
+    @results = ValidationService.new(path: @path).validate
+  end
+end

--- a/hydra/app/jobs/validate_job.rb
+++ b/hydra/app/jobs/validate_job.rb
@@ -3,7 +3,17 @@
 class ValidateJob < ApplicationJob
   queue_as :default
 
-  def perform(path:, mail_to:)
-    @results = ValidationService.new(path: @path).validate
+  def perform(path:, file_name:, mail_to:)
+    results = ValidationService.new(path: path).validate
+    ## clean up file after processing
+    if File.exist?(path)
+      File.delete(path)
+    end
+    # send the email
+    email_depositor(mail_to:, file_name:, content: results)
+  end
+
+  def email_depositor(mail_to:, file_name:, content:)
+    ValidationMailer.email_validation(mail_to:, file_name:, content:).deliver_now
   end
 end

--- a/hydra/app/jobs/validate_job.rb
+++ b/hydra/app/jobs/validate_job.rb
@@ -4,16 +4,15 @@ class ValidateJob < ApplicationJob
   queue_as :default
 
   def perform(path:, file_name:, mail_to:)
-    results = ValidationService.new(path: path).validate
-    ## clean up file after processing
-    if File.exist?(path)
-      File.delete(path)
-    end
-    # send the email
-    email_depositor(mail_to:, file_name:, content: results)
+    content = ValidationService.new(path:).validate
+
+    email_depositor(mail_to:, file_name:, content:, path:)
   end
 
-  def email_depositor(mail_to:, file_name:, content:)
+  def email_depositor(mail_to:, file_name:, content:, path:)
+debugger
     ValidationMailer.email_validation(mail_to:, file_name:, content:).deliver_now
+
+    File.delete(path) if File.exist?(path)
   end
 end

--- a/hydra/app/jobs/validate_job.rb
+++ b/hydra/app/jobs/validate_job.rb
@@ -10,9 +10,10 @@ class ValidateJob < ApplicationJob
   end
 
   def email_depositor(mail_to:, file_name:, content:, path:)
-debugger
     ValidationMailer.email_validation(mail_to:, file_name:, content:).deliver_now
 
     File.delete(path) if File.exist?(path)
+  rescue Net::OpenTimeout => e
+    Rails.logger.error("Emailer may not be set up correctly. #{e}")
   end
 end

--- a/hydra/app/mailers/validation_mailer.rb
+++ b/hydra/app/mailers/validation_mailer.rb
@@ -6,7 +6,7 @@ class ValidationMailer < ApplicationMailer
 
     # content is used by app/views/validation_mailer/email_validation.html.erb
     # to prepare body of email.
-    email = mail(
+    mail(
       :to => mail_to,
       :subject => "Validation results for file: #{file_name}",
       date: Time.now,

--- a/hydra/app/mailers/validation_mailer.rb
+++ b/hydra/app/mailers/validation_mailer.rb
@@ -2,6 +2,8 @@
 
 class ValidationMailer < ApplicationMailer
   def email_validation(mail_to:, file_name:, content:)
+    @content = content
+
     # content is used by app/views/validation_mailer/email_validation.html.erb
     # to prepare body of email.
     email = mail(

--- a/hydra/app/mailers/validation_mailer.rb
+++ b/hydra/app/mailers/validation_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidationMailer < ApplicationMailer
+  def email_validation(mail_to:, file_name:, content:)
+    # content is used by app/views/validation_mailer/email_validation.html.erb
+    # to prepare body of email.
+    email = mail(
+      :to => mail_to,
+      :subject => "Validation results for file: #{file_name}",
+      date: Time.now,
+      content_type: 'text/html'
+    )
+  end
+end

--- a/hydra/app/services/validation_service.rb
+++ b/hydra/app/services/validation_service.rb
@@ -85,7 +85,7 @@ class ValidationService
     # ensure we always return an array for consistency with split function
     term = Array.wrap(value)
     return term if value.nil? || check_split[header] == false
-    value.split(split_on)
+    value.split(split_on).map(&:strip)
   end
 
   # Use Bulkrax to determine if this header is one we split

--- a/hydra/app/services/validation_service.rb
+++ b/hydra/app/services/validation_service.rb
@@ -39,14 +39,17 @@ class ValidationService
 
   def validate
     csv_path = path
-    csv_data = File.read(csv_path)
+    if File.exist?(csv_path)
+      csv_data = File.read(csv_path)
 
-    headers = CSV.parse(csv_data, headers: true).headers
-    invalid_headers = headers - bulkrax_headers
-    results << invalid_headers.map { |header| { row: 1, header: header, message: "<strong>#{header}</strong> is an invalid header" } } if invalid_headers.present?
-
-    CSV.parse(csv_data, headers: true).each_with_index do |row, index|
-      validate_row(row: row, row_number: index + 2)
+      headers = CSV.parse(csv_data, headers: true).headers
+      invalid_headers = headers - bulkrax_headers
+      invalid_headers.map { |header| results << { row: 1, header: header, message: "<strong>#{header}</strong> is an invalid header" } } if invalid_headers.present?
+      CSV.parse(csv_data, headers: true).each_with_index do |row, index|
+        validate_row(row: row, row_number: index + 2)
+      end
+    else
+      results << { row: 1, header: "", message: "File missing at #{csv_path}" }
     end
 
     results

--- a/hydra/app/views/validation_mailer/email_validation.html.erb
+++ b/hydra/app/views/validation_mailer/email_validation.html.erb
@@ -17,9 +17,9 @@
     </style>
   </head>
   <body>
-    <% if content.any? %>
+    <% if @content.any? %>
       <div class="alert alert-warning">
-        Found <%= pluralize(content.size, 'issue') %>
+        Found <%= pluralize(@content.size, 'issue') %>
       </div>
 
       <table class="table">
@@ -31,7 +31,7 @@
           </tr>
         </thead>
         <tbody>
-          <% content.each do |result| %>
+          <% @content.each do |result| %>
             <tr>
               <td><%= result[:row] %></td>
               <td><%= result[:header] %></td>

--- a/hydra/app/views/validation_mailer/email_validation.html.erb
+++ b/hydra/app/views/validation_mailer/email_validation.html.erb
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th, td {
+        border: 1px solid black;
+        padding: 8px;
+        text-align: left;
+      }
+      th {
+        background-color: #f2f2f2;
+      }
+    </style>
+  </head>
+  <body>
+    <% if content.any? %>
+      <div class="alert alert-warning">
+        Found <%= pluralize(content.size, 'issue') %>
+      </div>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Row</th>
+            <th>Field</th>
+            <th>Issue</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% content.each do |result| %>
+            <tr>
+              <td><%= result[:row] %></td>
+              <td><%= result[:header] %></td>
+              <td><%= result[:message].html_safe %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <div class="alert alert-success">
+        No validation issues found!
+      </div>
+    <% end %>
+  </body>
+</html>

--- a/hydra/app/views/validations/upload.html.erb
+++ b/hydra/app/views/validations/upload.html.erb
@@ -7,7 +7,7 @@
       <%= form.file_field :csv_file, accept: ".csv" %>
       <div>
         <%= form.check_box :background_job?, id: 'checkbox' %>
-        <%= form.label :background_job, "Run as Background Job and email results to " %>
+        <%= form.label :background_job, "Run as Background Job and email results to ", for: 'checkbox' %>
         <%= form.email_field :mail_to, placeholder: "Enter your email", id: 'mail_to' %>
       </div>
       <%= form.submit "Upload & Validate", class: 'btn btn-primary' %>

--- a/hydra/app/views/validations/upload.html.erb
+++ b/hydra/app/views/validations/upload.html.erb
@@ -5,6 +5,11 @@
     <div class="form-group">
       <%= form.label :csv_file, "Upload CSV" %>
       <%= form.file_field :csv_file, accept: ".csv" %>
+      <div>
+        <%= form.check_box :background_job?, id: 'checkbox' %>
+        <%= form.label :background_job, "Run as Background Job and email results to " %>
+        <%= form.email_field :mail_to, placeholder: "Enter your email", id: 'mail_to' %>
+      </div>
       <%= form.submit "Upload & Validate", class: 'btn btn-primary' %>
     </div>
   <% end %>

--- a/hydra/config/environments/development.rb
+++ b/hydra/config/environments/development.rb
@@ -67,14 +67,13 @@ Rails.application.configure do
   # Email Tests
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries    = true
-  config.action_mailer.delivery_method       = :smtp
+  config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.default_url_options   = { :host => 'localhost:3000' }
-
-  config.action_mailer.smtp_settings = {
-    address: "smtp.wvu.edu",
-    port: 25,
-    enable_starttls_auto: true
-  }
+  # config.action_mailer.smtp_settings = {
+  #   address: "smtp.wvu.edu",
+  #   port: 25,
+  #   enable_starttls_auto: true
+  # }
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/hydra/config/routes.rb
+++ b/hydra/config/routes.rb
@@ -64,4 +64,7 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # Access your emails by visiting http://localhost:3000/letter_opener in your browser.
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/hydra/spec/mailers/previews/validation_mailer_preview.rb
+++ b/hydra/spec/mailers/previews/validation_mailer_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ValidationMailerPreview < ActionMailer::Preview
+  # view preview at: http://localhost:3000/rails/mailers/validation_mailer/email_validation
+  def email_validation
+    mail_to = 'test@test.test'
+    file_name = 'test.csv'
+    content = [
+      { row: 2, header: "dcterms:creator", message: "<strong>Invalid Author Name</strong> was not found in LC Linked Data Service" },
+      { row: 3, header: "dcterms:created", message: "<strong>2023-13-45</strong> is not a valid EDTF" },
+      { row: 4, header: "dcterms:language", message: "<strong>xxx</strong> is not a valid language code" },
+      { row: 5, header: "dcterms:spatial", message: "<strong>Invalid City (city)</strong> was not found in Getty TGN" },
+      { row: 6, header: "edm:isShownAt", message: "<strong>invalid-url</strong> is an invalid URL format" },
+      { row: 7, header: "dcterms:type", message: "<strong>Invalid Type</strong> is not valid" },
+      { row: 8, header: "invalid_header", message: "<strong>invalid_header</strong> is an invalid header" },
+      { row: 9, header: "dcterms:title", message: "Missing required value" }
+    ]
+
+    ValidationMailer.email_validation(mail_to:, file_name:, content:)
+  end
+end


### PR DESCRIPTION
# Story

Refs:

- https://github.com/scientist-softserv/west-virginia-university/issues/171

# Expected Behavior Before Changes

Validation could only be done via the browser page.

# Expected Behavior After Changes

Validations can be submitted to a background job, with results sent via email.
In development mode, emails can be viewed at `http://localhost:3000/letter_opener/`

# Screenshots / Video

<details>
<summary>Screenshots</summary>

![Screenshot 2024-12-18 at 3 50 45 PM](https://github.com/user-attachments/assets/291d42d7-9917-4bc3-9281-8157abcc9f76)

![Screenshot 2024-12-18 at 3 42 10 PM](https://github.com/user-attachments/assets/108a2034-ae11-4e52-bf7b-ec3622a3e0c7)


</details>

# Notes
May require additional mailer configuration in staging or development if that isn't already working. If staging doesn't use email, letter_opener gem can be configured to handle staging as well.