### PR TITLE
Restore use of controller decorators

### DIFF
--- a/hydra/app/controllers/bulkrax/exporters_controller_decorator.rb
+++ b/hydra/app/controllers/bulkrax/exporters_controller_decorator.rb
@@ -10,4 +10,4 @@ module Bulkrax::ExportersControllerDecorator
   end
 end
 
-# Bulkrax::ExportersController.prepend(Bulkrax::ExportersControllerDecorator)
+Bulkrax::ExportersController.prepend(Bulkrax::ExportersControllerDecorator)

--- a/hydra/app/controllers/bulkrax/importers_controller_decorator.rb
+++ b/hydra/app/controllers/bulkrax/importers_controller_decorator.rb
@@ -10,4 +10,4 @@ module Bulkrax::ImportersControllerDecorator
   end
 end
 
-# Bulkrax::ImportersController.prepend(Bulkrax::ImportersControllerDecorator)
+Bulkrax::ImportersController.prepend(Bulkrax::ImportersControllerDecorator)


### PR DESCRIPTION
# Story

Fixing `current_user` for bookmarks broke it for bulkrax importers and exporters. 

# Expected Behavior Before Changes

Hitting `importers/new` or `exporters/new` threw a form error.

# Expected Behavior After Changes

Able to create a new importer or exporter.
Import completed successfully.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2024-12-23 at 2 36 46 PM](https://github.com/user-attachments/assets/180b91cd-dded-4412-8944-d3728b7f6918)

</details>

# Notes
