### PR TITLE
🐛 Fix search results export

### DIFF
--- a/hydra/app/controllers/catalog_controller.rb
+++ b/hydra/app/controllers/catalog_controller.rb
@@ -236,6 +236,7 @@ class CatalogController < ApplicationController
   # end
 
   def export
+    blacklight_config.max_per_page = params[:rows]
     @response = search_service.search_results[0]
 
     respond_to do |format|

--- a/hydra/app/views/catalog/_export_search_results.html.erb
+++ b/hydra/app/views/catalog/_export_search_results.html.erb
@@ -7,12 +7,14 @@
     <li><%= link_to "Export to CSV", catalog_export_path(rows: @response.total,
                                                         format: :csv,
                                                         search_field: export_params[:search_field],
-                                                        q: export_params[:q]),
+                                                        q: export_params[:q],
+                                                        f: export_params[:f]&.permit!&.to_h),
                                                         class: "dropdown-item" %></li>
     <li><%= link_to "Export to XML", catalog_export_path(rows: @response.total,
                                                         format: :xml,
                                                         search_field: export_params[:search_field],
-                                                        q: export_params[:q]),
+                                                        q: export_params[:q],
+                                                        f: export_params[:f]&.permit!&.to_h),
                                                         class: "dropdown-item" %></li>
   </ul>
 </div>


### PR DESCRIPTION
The export was not working properly, it was capped at 100 previously. This commit will set it to the number of reponse results.  Also, we are now passing in the f param so faceted searches are exported properly.

Ref:
- https://github.com/notch8/west-virginia-university/issues/183
