### PR TITLE
Add exceptions to validation service

### DIFF
--- a/hydra/app/controllers/validations_controller.rb
+++ b/hydra/app/controllers/validations_controller.rb
@@ -33,10 +33,15 @@ class ValidationsController < ApplicationController
   private
 
   def submit_validate_job
-    ValidateJob.perform_later(path: @path.to_s, file_name: params['csv_file'].original_filename, mail_to: params[:mail_to])
+    ValidateJob.perform_later(
+      path: @path.to_s,
+      file_name: params['csv_file'].original_filename,
+      mail_to: params[:mail_to],
+      validate_urls: params[:validate_urls] == '1'
+    )
   end
 
   def validate_file
-    ValidationService.new(path: @path).validate
+    ValidationService.new(path: @path, validate_urls: params[:validate_urls] == '1').validate
   end
 end

--- a/hydra/app/jobs/validate_job.rb
+++ b/hydra/app/jobs/validate_job.rb
@@ -3,8 +3,8 @@
 class ValidateJob < ApplicationJob
   queue_as :default
 
-  def perform(path:, file_name:, mail_to:)
-    content = ValidationService.new(path:).validate
+  def perform(path:, file_name:, mail_to:, validate_urls: false)
+    content = ValidationService.new(path:, validate_urls:).validate
 
     email_depositor(mail_to:, file_name:, content:, path:)
   end

--- a/hydra/app/views/validations/upload.html.erb
+++ b/hydra/app/views/validations/upload.html.erb
@@ -6,6 +6,10 @@
       <%= form.label :csv_file, "Upload CSV" %>
       <%= form.file_field :csv_file, accept: ".csv" %>
       <div>
+        <%= form.check_box :validate_urls?, id: 'validate_urls' %>
+        <%= form.label :validate_urls, "Validate URLs to ensure successful resolution (much slower)", for: 'checkbox' %>
+      </div>
+      <div>
         <%= form.check_box :background_job?, id: 'checkbox' %>
         <%= form.label :background_job, "Run as Background Job and email results to ", for: 'checkbox' %>
         <%= form.email_field :mail_to, placeholder: "Enter your email", id: 'mail_to' %>


### PR DESCRIPTION
We are adding 'undated' and 'unknown' to the EDTF and creator validations respectively.  Since these are the only two exceptions, we're fine with not changing the code too much to accommodate.  If in the future, we are seeing more exceptions, then we would want to refactor the validation service to handle exceptions better.

In addition, we are using the #is_active_url? method from ApplicationHelper in the service, but we want to give the user the option to either do a quick check (check if string starts with "http") or a full check whether the URL resolves correctly or not.

<img width="652" alt="image" src="https://github.com/user-attachments/assets/382b1bb4-283e-423a-9b26-084a72517874" />
